### PR TITLE
Fix command plugin

### DIFF
--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -181,7 +181,7 @@ class Commands(dict):
         self.guard = guard(bot)
 
     @irc3.event((r':(?P<mask>\S+) PRIVMSG (?P<target>\S+) '
-                 r':{cmd}(?P<cmd>\w+)(\s(?P<data>[-0-9A-z]+.*)|$)'))
+                 r':{cmd}(?P<cmd>\w+)(\s(?P<data>[-0-9A-z-#-&]+.*)|$)'))
     def on_command(self, cmd, mask=None, target=None, data=None, **kw):
         predicates, meth = self.get(cmd, (None, None))
         if meth is not None:


### PR DESCRIPTION
@command can't use channel name on first args (ex : %%join #channel)
