### PR TITLE
Changed `cmdchar` to `cmd` in config defaults

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -98,7 +98,7 @@ class IrcBot(object):
         ssl=False,
         timeout=320,
         max_lag=60,
-        cmdchar='!',
+        cmd='!',
         encoding='utf8',
         testing=False,
         async=True,


### PR DESCRIPTION
The `command` plugin uses `cmd`, not `cmdchar` for this variable.
