### PR TITLE
Add option to add venusian_categories

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -127,6 +127,7 @@ class IrcBot(object):
         ),
         loop=None,
         connection=IrcConnection,
+        categories=[]
     )
 
     def __init__(self, *ini, **config):
@@ -152,6 +153,8 @@ class IrcBot(object):
             'in': defaultdict(list),
             'out': defaultdict(list)
         }
+
+        self.venusian_categories.extend(self.config.get('categories'))
 
         self.plugins = {}
         self.includes = set()


### PR DESCRIPTION
This is for plugins which need additional venusian_categories to scan when loading sub-plugins similar to the command plugin included.

See https://github.com/TronPaul/irc3-extras/blob/master/irc3_extras/title.py
