### PR TITLE
Use extended interpolation for parsing config file

### DIFF
--- a/irc3/utils.py
+++ b/irc3/utils.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-try:
-    import configparser
-except ImportError:  # pragma: no cover
-    import ConfigParser as configparser
+import configparser
 
 try:
     BaseString = unicode

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ if sys.version_info[:2] < (3, 0):
     install_requires.extend([
         'trollius',
         'futures',
+        'configparser',
     ])
     test_requires.extend(['mock'])
 elif sys.version_info[:2] < (3, 3):


### PR DESCRIPTION
See https://docs.python.org/3/library/configparser.html#interpolation-of-values.

I made this pull request because I noticed that when I wanted to customize the output location of the log file, I got funky errors on Python 3. Here's the relevant section of my configuration file:

``` ini
[irc3.plugins.logger]
handler = irc3.plugins.logger.s3_handler
bucket = my-irc-log-bucket
filename = irclogs/{channel}-{date:%Y-%m-%d}.log
```

Which resulted in this error on Python 3:

```
Traceback (most recent call last):
  File "/app/.heroku/python/bin/irc3", line 9, in <module>
    load_entry_point('irc3==0.5.2.dev0', 'console_scripts', 'irc3')()
  File "/app/.heroku/python/lib/python3.4/site-packages/irc3/__init__.py", line 432, in run
    cfg = utils.parse_config(*args['<config>'])
  File "/app/.heroku/python/lib/python3.4/site-packages/irc3/utils.py", line 142, in parse_config
    for k, v in config.items(s):
  File "/app/.heroku/python/lib/python3.4/configparser.py", line 836, in items
    return [(option, value_getter(option)) for option in d.keys()]
  File "/app/.heroku/python/lib/python3.4/configparser.py", line 836, in <listcomp>
    return [(option, value_getter(option)) for option in d.keys()]
  File "/app/.heroku/python/lib/python3.4/configparser.py", line 833, in <lambda>
    section, option, d[option], d)
  File "/app/.heroku/python/lib/python3.4/configparser.py", line 374, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/app/.heroku/python/lib/python3.4/configparser.py", line 423, in _interpolate_some
    "found: %r" % (rest,))
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%Y-%m-%d}.log'
```
