### PR TITLE
Sort feed entries with the date field only.

### DIFF
--- a/irc3/plugins/feeds.py
+++ b/irc3/plugins/feeds.py
@@ -61,6 +61,7 @@ import time
 import irc3
 import datetime
 from concurrent.futures import ThreadPoolExecutor
+from operator import itemgetter
 
 
 def default_hook(entries):
@@ -108,7 +109,7 @@ def parse(feedparser, args):
             e['feed'] = args
             entries.append((e.updated, e))
         if entries:
-            entries = sorted(entries)
+            entries = sorted(entries, key=itemgetter(0))
             with open(filename + '.updated', 'w') as fd:
                 fd.write(str(entries[-1][0]))
     return entries


### PR DESCRIPTION
Otherwise, if there are multiple entries at the same date, this fails
because the second field is a `FeedParserDict` which is not sortable.
