### PR TITLE
Let `get_plugin()` support unicode arguments

### DIFF
--- a/irc3/base.py
+++ b/irc3/base.py
@@ -78,7 +78,7 @@ class IrcObject(object):
         self.recompile()
 
     def get_plugin(self, ob):
-        if isinstance(ob, str):
+        if isinstance(ob, string_types):
             name = ob
             ob = utils.maybedotted(ob)
             if ob not in self.plugins:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from irc3.compat import u
 from irc3.testing import BotTestCase
 from irc3.testing import patch
 import logging
@@ -18,6 +19,8 @@ class TestBot(BotTestCase):
     def test_plugin(self):
         bot = self.callFTU()
         bot.include('irc3.plugins.command')
+        plugin = bot.get_plugin(u('irc3.plugins.command.Commands'))
+        self.assertTrue(plugin is not None)
         plugin = bot.get_plugin('irc3.plugins.command.Commands')
         self.assertTrue(plugin is not None)
         self.assertRaises(LookupError, bot.get_plugin,


### PR DESCRIPTION
Have it compare the input with `irc3.compat.string_types` instead of using
`str`.
