### PR TITLE
Drop using the configparser module while ConfigParser is in py2 stdlib

### DIFF
--- a/irc3/compat.py
+++ b/irc3/compat.py
@@ -19,7 +19,7 @@ else:  # pragma: no cover
 if PY3:  # pragma: no cover
     import configparser
 else:  # pragma: no cover
-    from backports import configparser  # NOQA
+    import ConfigParser as configparser  # NOQA
 
 try:  # pragma: no cover
     import asyncio

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ if py_ver < (3, 0):
     install_requires.extend([
         'trollius',
         'futures',
-        'configparser',
     ])
     test_requires.extend(['mock'])
 elif py_ver < (3, 3):


### PR DESCRIPTION
Fixes https://github.com/gawel/irc3/issues/28
