### PR TITLE
According to the documentation no need to complexify

### DIFF
--- a/irc3/compat.py
+++ b/irc3/compat.py
@@ -16,10 +16,7 @@ else:  # pragma: no cover
     text_type = unicode
     string_types = basestring
 
-if PY3:  # pragma: no cover
-    import configparser
-else:  # pragma: no cover
-    from backports import configparser  # NOQA
+import configparser
 
 try:  # pragma: no cover
     import asyncio


### PR DESCRIPTION
import configparser will work on both py2 and py3, on py2 it will import the
backport version and on py3 the stdlib one

Using from backports import configparser is actually only useful if want to use
the backport version on both py2 and py3
