### PR TITLE
added invite command and event

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -215,6 +215,10 @@ class IrcBot(base.IrcObject):
             target += ' :' + reason
         self.send_line('KICK %s %s' % (channel, target))
 
+    def invite(self, target, channel):
+        """invite target to a channel"""
+        self.send_line('INVITE %s %s' % (target, channel))
+
     def quit(self, reason=None):
         """disconnect"""
         if not reason:

--- a/irc3/rfc.py
+++ b/irc3/rfc.py
@@ -69,6 +69,11 @@ CTCP = raw.new(
     ('^:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
      '{nick} :\x01(?P<ctcp>\S+.*)\x01$'))
 
+INVITE = raw.new(
+    'INVITE',
+    (r':(?P<mask>\S+!\S+@\S+) INVITE {nick} :?(?P<channel>\S+)')
+)
+
 ERR_NICK = raw.new(
     'ERR_NICK',
     "^:(?P<srv>\S+) (?P<retcode>(432|433|436)) (?P<me>\S+) "


### PR DESCRIPTION
An example plugin using the invite command and event:
```python
# -*- coding: utf-8 -*-

import irc3
from irc3 import rfc
from irc3.plugins.command import command


@irc3.plugin
class Test:

    requires = [
        'irc3.plugins.core',
        'irc3.plugins.command',
    ]

    def __init__(self, bot):
        self.bot = bot
        self.log = self.bot.log

    @irc3.event(rfc.INVITE)
    def on_invite(self, mask, channel):
        self.bot.join(channel)
        self.bot.loop.call_later(2, self.bot.privmsg, channel, "Thanks %s !" % mask.nick)

    @command
    def invite(self, mask, target, args):
        """
        Invite a user to the current channel

        %%invite <nick>
        """
        self.bot.invite(args['<nick>'], target)
```