### PR TITLE
unnecessary logging

### DIFF
--- a/examples/mybot.py
+++ b/examples/mybot.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging.config
 from irc3.plugins.command import command
-import logging
 import irc3
 
 
@@ -76,9 +74,6 @@ class MyPlugin:
 
 
 def main():
-    # logging configuration
-    logging.config.dictConfig(irc3.config.LOGGING)
-
     # instanciate a bot
     irc3.IrcBot(
         nick='irc3', autojoins=['#irc3'],


### PR DESCRIPTION
The configuration of the logging module happens here: <https://github.com/gawel/irc3/blob/master/irc3/base.py#L75>. This can lead new users to think they can set a custom logging configuration before instanciate the bot, but I think dictConfig() overrides the previous calls.