### PR TITLE
Fixes bug in userlist plugin

### DIFF
--- a/irc3/plugins/userlist.py
+++ b/irc3/plugins/userlist.py
@@ -190,7 +190,7 @@ class Userlist(object):
                 nicknames = channel.modes[prefix[mode]]
                 if char == '+':
                     nicknames.add(tgt)
-                elif target in nicknames:
+                elif tgt in nicknames:
                     nicknames.remove(tgt)
                 if client is not None:
                     broadcast = (


### PR DESCRIPTION
Users were never removed upon being devoiced or deopped because of an incorrect check in the mode event. Should be checking tgt instead of target.