### PR TITLE
Casefold regarding the IRC server's casemapping

### DIFF
--- a/docs/plugins/casefold.rst
+++ b/docs/plugins/casefold.rst
@@ -1,0 +1,2 @@
+.. automodule:: irc3.plugins.casefold
+

--- a/irc3/plugins/casefold.py
+++ b/irc3/plugins/casefold.py
@@ -48,11 +48,14 @@ class Casefold(object):
     # casemapping
     @irc3.event(r'^:\S+ 005 \S+ .+CASEMAPPING.*')
     def recalculate_casemaps(self):
-        casemapping = self.bot.config.get('server_config', {}).get('CASEMAPPING', 'rfc1459')
+        casemapping = self.bot.config['server_config'].get('CASEMAPPING',
+                                                           'rfc1459')
 
         if casemapping == 'rfc1459':
-            lower_chars = string.ascii_lowercase + ''.join(chr(i) for i in range(123, 127))
-            upper_chars = string.ascii_uppercase + ''.join(chr(i) for i in range(91, 95))
+            lower_chars = (string.ascii_lowercase +
+                           ''.join(chr(i) for i in range(123, 127)))
+            upper_chars = (string.ascii_uppercase +
+                           ''.join(chr(i) for i in range(91, 95)))
 
         elif casemapping == 'ascii':
             lower_chars = string.ascii_lowercase

--- a/irc3/plugins/casefold.py
+++ b/irc3/plugins/casefold.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from irc3.compat import text_type
+import functools
+import string
+import irc3
+__doc__ = '''
+================================================
+:mod:`irc3.plugins.casefold` casefolding plugin
+================================================
+
+This command introduces a `bot.casefold` function that casefolds strings based
+on the current casemapping of the IRC server.
+
+This lets you casefold nicks and channel names so that on a server using
+rfc1459 casemapping, `#cool[chan]` and `#Cool{Chan}` are seen as the same
+channel.
+
+..
+    >>> from irc3.testing import IrcBot
+    >>> from irc3.testing import ini2config
+
+Usage::
+
+    >>> config = ini2config("""
+    ... [bot]
+    ... includes =
+    ...     irc3.plugins.casefold
+    ... """)
+    >>> bot = IrcBot(**config)
+
+Returning casefolded strings::
+
+    >>> bot.casefold('ThisIsANick')
+    'thisisanick'
+    >>> bot.casefold('#WeirdChannelNames[]')
+    '#weirdchannelnames{}'
+'''
+
+
+@irc3.plugin
+class Casefold(object):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.recalculate_casemaps()
+        self.bot.casefold = functools.partial(self.casefold)
+
+    # casemapping
+    @irc3.event(r'^:\S+ 005 \S+ .+CASEMAPPING.*')
+    def recalculate_casemaps(self):
+        casemapping = self.bot.config.get('server_config', {}).get('CASEMAPPING', 'rfc1459')
+
+        if casemapping == 'rfc1459':
+            lower_chars = string.ascii_lowercase + ''.join(chr(i) for i in range(123, 127))
+            upper_chars = string.ascii_uppercase + ''.join(chr(i) for i in range(91, 95))
+
+        elif casemapping == 'ascii':
+            lower_chars = string.ascii_lowercase
+            upper_chars = string.ascii_uppercase
+
+        table_in = (ord(char) for char in upper_chars)
+        self._lower_trans = dict(zip(table_in, text_type(lower_chars)))
+        return
+
+    def casefold(self, in_str):
+        """Casefold the given string, with the current server's casemapping."""
+        is_str = isinstance(in_str, str)
+        folded = text_type(in_str).translate(self._lower_trans)
+        if is_str:
+            return str(folded)
+        return folded


### PR DESCRIPTION
By default `irc3` doesn't do any casefolding on nicks/channels/etc. This can create issues in things like the `userlist` plugin where channels are seen as different where they should be the same, accessing user nicks can be problematic, etc.

I've made this a core plugin rather than putting it in `irc3_plugins` because I think the core should be casefolding things like its data structures, the `userlist` plugin, etc.

**Note:** This is an in-progress PR, I'm planning to make the `userlist` plugin use this by default.