### PR TITLE
Don't reject commands with trailing spaces

### DIFF
--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -245,7 +245,7 @@ class Commands(dict):
         self.tasks = defaultdict(Done)
 
     @irc3.event((r':(?P<mask>\S+) PRIVMSG (?P<target>\S+) '
-                 r':{re_cmd}(?P<cmd>\w+)(\s(?P<data>\S.*)|$)'))
+                 r':{re_cmd}(?P<cmd>\w+)(\s(?P<data>\S.*)|(\s*$))'))
     def on_command(self, cmd, mask=None, target=None, client=None, **kw):
         if not self.case_sensitive:
             cmd = cmd.lower()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,6 +103,14 @@ class TestCommands(BotTestCase):
         self.assertSent(
             ['PRIVMSG bar :Available commands: |help, |ping'])
 
+    def test_command_trailing_space(self):
+        bot = self.callFTU(nick='foo')
+        bot.dispatch(':bar!user@host PRIVMSG foo :!ping')
+        bot.dispatch(':bar!user@host PRIVMSG foo :!ping ')
+        bot.dispatch(':bar!user@host PRIVMSG foo :!ping  ')
+        self.assertSent(
+            ['NOTICE bar :PONG bar!']*3)
+
     def test_private_command(self):
         bot = self.callFTU()
         bot.dispatch(':bar!user@host PRIVMSG nono :!ping')


### PR DESCRIPTION
Currently the command `!help ` will get ignored because the trialing
space isn't allowed in the command regexp.