### PR TITLE
Allow to hide commands from !help

### DIFF
--- a/examples/mycommands.py
+++ b/examples/mycommands.py
@@ -19,3 +19,12 @@ def adduser(bot, mask, target, args):
         %%adduser <name> <password>
     """
     bot.privmsg(mask.nick, 'User added')
+
+
+@command(show_in_help_list=False)
+def my_secret_operation(bot, mask, target, args):
+    """Do something you don't want in !help all the time
+
+        %%my_secret_operation
+    """
+    bot.privmsg(mask.nick, "I like turtles")

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -55,6 +55,12 @@ When a command is not public, you can't use it on a channel::
     >>> bot.test(':gawel!user@host PRIVMSG #chan :!adduser foo pass')
     PRIVMSG gawel :You can only use the 'adduser' command in private.
 
+If a command is tagged with ``show_in_help_list=False``, it won't be shown
+on the result of ``!help``.
+
+    >>> bot.test(':gawel!user@host PRIVMSG #chan :!help')
+    PRIVMSG #chan :Available commands: !adduser, !echo, !help, !ping
+
 Guard
 =====
 
@@ -354,8 +360,11 @@ class Commands(dict):
                         line = line.replace('%%', self.context.config.cmd)
                         yield line
         else:
-            cmds = ', '.join([self.cmd + k for k in sorted(self.keys())])
-            lines = utils.split_message('Available commands: ' + cmds, 160)
+            cmds = sorted((k for (k, (p, m)) in self.items()
+                           if p.get('show_in_help_list', True)))
+            cmds_str = ', '.join([self.cmd + k for k in cmds])
+            lines = utils.split_message(
+                'Available commands: %s ' % cmds_str, 160)
             for line in lines:
                 yield line
             url = self.config.get('url')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,7 +13,9 @@ import codecs
 import os
 
 
-@command.command(permission='myperm', options_first=True)
+@command.command(permission='myperm',
+                 show_in_help_list=False,
+                 options_first=True)
 @dcc.dcc_command(options_first=True)
 def cmd(bot, *args):
     """Test command
@@ -63,6 +65,18 @@ class TestCommands(BotTestCase):
         bot.dispatch(':bar!user@host PRIVMSG #chan :!help')
         self.assertSent(
             ['PRIVMSG #chan :Available commands: !help, !ping'])
+
+    def test_help_hides(self):
+        bot = self.callFTU(nick='foo')
+        bot.include(__name__)
+        # For direct messages
+        bot.dispatch(':bar!user@host PRIVMSG foo :!help')
+        self.assertSent(
+            ['PRIVMSG bar :Available commands: !cmd_view, !help, !ping'])
+        # channel messages
+        bot.dispatch(':bar!user@host PRIVMSG #chan :!help')
+        self.assertSent(
+            ['PRIVMSG #chan :Available commands: !cmd_view, !help, !ping'])
 
     def test_help_with_url(self):
         bot = self.callFTU(nick='foo', **{


### PR DESCRIPTION
Because sometimes you don't want your average user to start trying out !quit (even though he will probably not be able to run it).