### PR TITLE
Prevent keyerror when setting keys that don't exist.

### DIFF
--- a/irc3/plugins/storage.py
+++ b/irc3/plugins/storage.py
@@ -272,7 +272,7 @@ class Storage(object):
         stored = self.get(key_, dict())
         changed = False
         for k, v in kwargs.items():
-            if stored[k] != v:
+            if k not in stored or stored[k] != v:
                 stored[k] = v
                 changed = True
         if changed:


### PR DESCRIPTION
iterating over kwargs isn't a great idea if you don't check if the key exists.