### PR TITLE
Ignore cache directory created by testing tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 _build
 .bzr
 .bzrignore
+.cache
 .chutifab
 .coverage
 coverage*
@@ -32,6 +33,7 @@ parts
 *.pyc
 *.pyd
 *.pyo
+.ropeproject/
 *.so
 src
 .svn


### PR DESCRIPTION
Dunno where it exactly came from, but I suddenly had a `.cache` folder after running tox.

Also added .ropeproject to the ignore rules for rope users