### PR TITLE
added basic support for IRCv3.2 tags

### DIFF
--- a/examples/mybot.py
+++ b/examples/mybot.py
@@ -29,7 +29,7 @@ class MyPlugin:
         """triggered when connection is lost"""
 
     @irc3.event(irc3.rfc.JOIN)
-    def welcome(self, mask, channel):
+    def welcome(self, mask, channel, **kw):
         """Welcome people who join a channel"""
         if mask.nick != self.bot.nick:
             self.bot.call_with_human_delay(

--- a/examples/mybot_plugin.py
+++ b/examples/mybot_plugin.py
@@ -10,7 +10,7 @@ class Plugin(object):
         self.bot = bot
 
     @irc3.event(irc3.rfc.JOIN)
-    def say_hi(self, mask, channel):
+    def say_hi(self, mask, channel, **kw):
         """Say hi when someone join a channel"""
         if mask.nick != self.bot.nick:
             self.bot.privmsg(channel, 'Hi %s!' % mask.nick)

--- a/examples/nickserv.py
+++ b/examples/nickserv.py
@@ -2,9 +2,9 @@
 import irc3
 
 
-@irc3.event(r':(?P<ns>NickServ)!NickServ@services. NOTICE (?P<nick>irc3) :'
-            r'This nickname is registered.*')
-def register(bot, ns=None, nick=None):
+@irc3.event(r'(@(?P<tags>\S+) )?:(?P<ns>NickServ)!NickServ@services.'
+            r' NOTICE (?P<nick>irc3) :This nickname is registered.*')
+def register(bot, ns=None, nick=None, **kw):
     try:
         password = bot.config[bot.config.host][nick]
     except KeyError:

--- a/irc3/base.py
+++ b/irc3/base.py
@@ -257,6 +257,10 @@ class IrcObject(object):
             for key, value in match.items():
                 if value is not None:
                     match[key] = str(value)
+            # backwards compatibility fix for IRCv3.2 tag support:
+            # If no tags (None-value), exclude from dictionary
+            if match.get("tags", True) is None:
+                del match["tags"]
             if client is not None:
                 # server / dcc chat
                 match['client'] = client

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -262,7 +262,7 @@ class Commands(dict):
         self.handles = defaultdict(Done)
         self.tasks = defaultdict(Done)
 
-    @irc3.event((r':(?P<mask>\S+) PRIVMSG (?P<target>\S+) '
+    @irc3.event((r'(@(?P<tags>\S+) )?:(?P<mask>\S+) PRIVMSG (?P<target>\S+) '
                  r':{re_cmd}(?P<cmd>\w+)(\s(?P<data>\S.*)|(\s*$))'))
     def on_command(self, cmd, mask=None, target=None, client=None, **kw):
         if not self.case_sensitive:

--- a/irc3/plugins/human.py
+++ b/irc3/plugins/human.py
@@ -75,7 +75,7 @@ class Human(object):
             fd.write(u'\n'.join(quotes))
 
     @irc3.event(irc3.rfc.MY_PRIVMSG)
-    def on_message(self, mask=None, event=None, target=None, data=None):
+    def on_message(self, mask=None, event=None, target=None, data=None, **kw):
         with codecs.open(self.db, 'ab+', encoding=self.bot.encoding) as fd:
             fd.write(data + '\n')
 

--- a/irc3/plugins/logger.py
+++ b/irc3/plugins/logger.py
@@ -83,14 +83,14 @@ class Logger(object):
                   **kwargs)
         self.handler(kw)
 
-    @irc3.event((r''':(?P<mask>\S+) (?P<event>[A-Z]+) (?P<target>#\S+)'''
-                 r'''(\s:(?P<data>.*)|$)'''))
+    @irc3.event((r'''(@(?P<tags>\S+) )?:(?P<mask>\S+) (?P<event>[A-Z]+)'''
+                 r''' (?P<target>#\S+)(\s:(?P<data>.*)|$)'''))
     def on_input(self, mask, event, target=None, data=None, **kwargs):
         if target and target.is_channel:
             self.process(event=event, mask=mask,
                          channel=target, data=data, **kwargs)
 
-    @irc3.event((r'''(?P<event>[A-Z]+) (?P<target>#\S+)'''
+    @irc3.event((r'''(@(?P<tags>\S+) )?(?P<event>[A-Z]+) (?P<target>#\S+)'''
                  r'''(\s:(?P<data>.*)|$)'''), iotype='out')
     def on_output(self, event, target=None, data=None, **kwargs):
         if target and target.is_channel:

--- a/irc3/rfc.py
+++ b/irc3/rfc.py
@@ -13,11 +13,15 @@ class raw(str):
         r = cls(name)
         r.name = name
         r.re = regexp
-        if regexp.startswith((':', '^:')):
+        if regexp.startswith((':', '^:', '(@', '^(@')):
             name = 'SERVER_' + name
             r.server = cls(name)
             r.server.name = name
-            r.server.re = regexp.split(' ', 1)[1]
+            if regexp.startswith(('(@', '^(@')):
+                r.server.re = regexp.split(' ', 2)[2]
+                r.server.re = r'(@(?P<tags>\S+) )?' + r.server.re
+            else:
+                r.server.re = regexp.split(' ', 1)[1]
         return r
 
 CONNECTED = raw.new('CONNECTED',
@@ -26,58 +30,64 @@ CONNECTED = raw.new('CONNECTED',
 PING = raw.new('PING', r'^PING :?(?P<data>.*)')
 PONG = raw.new(
     'PONG',
-    r'^:(?P<server>\S+) PONG (?P=server) :?(?P<data>.*)')
+    r'^(@(?P<tags>\S+) )?:(?P<server>\S+) PONG (?P=server) :?(?P<data>.*)')
 
-NEW_NICK = raw.new('NEW_NICK', r'^:(?P<nick>\S+) NICK :?(?P<new_nick>\S+)')
+NEW_NICK = raw.new('NEW_NICK',
+                   (r'^(@(?P<tags>\S+) )?:(?P<nick>\S+) '
+                    r'NICK :?(?P<new_nick>\S+)'))
 
-JOIN = raw.new('JOIN', r'^:(?P<mask>\S+) JOIN :?(?P<channel>\S+)')
+JOIN = raw.new('JOIN',
+               r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) JOIN :?(?P<channel>\S+)')
 PART = raw.new('PART',
-               r'^:(?P<mask>\S+) PART (?P<channel>\S+)(\s+:(?P<data>.*)|$)')
+               (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) '
+                r'PART (?P<channel>\S+)(\s+:(?P<data>.*)|$)'))
 QUIT = raw.new('QUIT',
-               r'^:(?P<mask>\S+) QUIT(\s+:(?P<data>.*)|$)')
+               r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) QUIT(\s+:(?P<data>.*)|$)')
 
 JOIN_PART_QUIT = raw.new(
     'JOIN_PART_QUIT',
-    (r'^:(?P<mask>\S+) '
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) '
      r'(?P<event>JOIN|PART|QUIT)\s*:*(?P<channel>\S*)(\s+:(?P<data>.*)|$)'))
 
 KICK = raw.new(
     'KICK',
-    (r'^:(?P<mask>\S+) '
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) '
      r'(?P<event>KICK)\s+(?P<channel>\S+)\s*(?P<target>\S+)'
      r'(\s+:(?P<data>.*)|$)'))
 
 MODE = raw.new(
     'MODE',
-    (r'^:(?P<mask>\S+) (?P<event>MODE)\s+'
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+) (?P<event>MODE)\s+'
      r'(?P<target>\S+)\s+(?P<modes>\S+)(\s+(?P<data>.*)|$)'
      ))
 
 MY_PRIVMSG = raw.new(
     'MY_PRIVMSG',
-    (r'^:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
         r'(?P<target>(#\S+|{nick})) :{nick}[:,\s]\s*'
         r'(?P<data>\S+.*)$'))
 
 PRIVMSG = raw.new(
     'PRIVMSG',
-    (r'^:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
      r'(?P<target>\S+) :\s*(?P<data>\S+.*)$'))
 
 CTCP = raw.new(
     'CTCP',
-    ('^:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
+    ('^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) (?P<event>(PRIVMSG|NOTICE)) '
      '{nick} :\x01(?P<ctcp>\S+.*)\x01$'))
 
 INVITE = raw.new(
     'INVITE',
-    (r'^:(?P<mask>\S+!\S+@\S+) INVITE {nick} :?(?P<channel>\S+)$'))
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) '
+     r'INVITE {nick} :?(?P<channel>\S+)$'))
 
 TOPIC = raw.new(
     'TOPIC',
-    (r'^:(?P<mask>\S+!\S+@\S+) TOPIC (?P<channel>\S+) :(?P<data>\S+.*)$'))
+    (r'^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) '
+     r'TOPIC (?P<channel>\S+) :(?P<data>\S+.*)$'))
 
 ERR_NICK = raw.new(
     'ERR_NICK',
-    "^:(?P<srv>\S+) (?P<retcode>(432|433|436)) (?P<me>\S+) "
+    "^(@(?P<tags>\S+) )?:(?P<srv>\S+) (?P<retcode>(432|433|436)) (?P<me>\S+) "
     "(?P<nick>\S+) :(?P<data>.*)")

--- a/irc3/tags.py
+++ b/irc3/tags.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+'''
+Module offering 2 functions, encode() and decode(), to transcode between
+IRCv3.2 tags and python dictionaries.
+'''
+import re
+import random
+import string
+
+
+_escapes = (
+    ("\\", "\\\\"),
+    (";",  r"\:"),
+    (" ",  r"\s"),
+    ("\r", r"\r"),
+    ("\n", r"\n"),
+)
+
+# make the possibility of the substitute actually appearing in the text
+# negligible. Even for targeted attacks
+_substitute = (";TEMP:%s;" %
+               ''.join(random.choice(string.ascii_letters) for i in range(20)))
+_unescapes = (
+    ("\\\\", _substitute),
+    (r"\:", ";"),
+    (r"\s", " "),
+    (r"\r", "\r"),
+    (r"\n", "\n"),
+    (_substitute, "\\"),
+)
+
+# valid tag-keys must contain of alphanumerics and hyphens only.
+# for vendor-tagnames: TLD with slash appended
+_valid_key = re.compile("^([\w.-]+/)?[\w-]+$")
+
+
+def _unescape(string):
+    for a, b in _unescapes:
+        string = string.replace(a, b)
+    return string
+
+
+def _escape(string):
+    for a, b in _escapes:
+        string = string.replace(a, b)
+    return string
+
+
+def encode(tags):
+    '''Encodes a dictionary of tags to fit into an IRC-message.
+    See IRC Message Tags: http://ircv3.net/specs/core/message-tags-3.2.html
+
+    >>> from collections import OrderedDict
+    >>> encode({'key': 'value'})
+    'key=value'
+
+    >>> d = {'aaa': 'bbb', 'ccc': None, 'example.com/ddd': 'eee'}
+    >>> d_ordered = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
+    >>> encode(d_ordered)
+    'aaa=bbb;ccc;example.com/ddd=eee'
+
+    >>> d = {'key': 'value;with special\\\\characters', 'key2': 'with=equals'}
+    >>> d_ordered = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
+    >>> print(encode(d_ordered))
+    key=value\\:with\\sspecial\\\characters;key2=with=equals
+
+    >>> print(encode({'key': r'\\something'}))
+    key=\\\\something
+
+    '''
+    tagstrings = []
+    for key, value in tags.items():
+        if not _valid_key.match(key):
+            raise KeyError("dictionary key is invalid as tag key: " + key)
+        # if no value, just append the key
+        if value:
+            tagstrings.append(key + "=" + _escape(value))
+        else:
+            tagstrings.append(key)
+    return ";".join(tagstrings)
+
+
+def decode(tagstring):
+    '''Decodes a tag-string from an IRC-message into a python dictionary.
+    See IRC Message Tags: http://ircv3.net/specs/core/message-tags-3.2.html
+
+    >>> from pprint import pprint
+    >>> pprint(decode('key=value'))
+    {'key': 'value'}
+
+    >>> pprint(decode('aaa=bbb;ccc;example.com/ddd=eee'))
+    {'aaa': 'bbb', 'ccc': None, 'example.com/ddd': 'eee'}
+
+    >>> s = r'key=value\\:with\\sspecial\\\\characters;key2=with=equals'
+    >>> pprint(decode(s))
+    {'key': 'value;with special\\\\characters', 'key2': 'with=equals'}
+    >>> print(decode(s)['key'])
+    value;with special\\characters
+
+    >>> print(decode(r'key=\\\\something')['key'])
+    \\something
+
+    '''
+    if not tagstring:
+        # None/empty = no tags
+        return {}
+
+    tags = {}
+
+    for tag in tagstring.split(";"):
+        # value is either everything after "=", or None
+        key, value = (tag.split("=", 1) + [None])[:2]
+        if value:
+            value = _unescape(value)
+        tags[key] = value
+
+    return tags

--- a/irc3/template/plugin.py
+++ b/irc3/template/plugin.py
@@ -10,7 +10,7 @@ class Plugin(object):
         self.bot = bot
 
     @irc3.event(irc3.rfc.JOIN)
-    def say_hi(self, mask, channel):
+    def say_hi(self, mask, channel, **kw):
         """Say hi when someone join a channel"""
         if mask.nick != self.bot.nick:
             self.bot.privmsg(channel, 'Hi %s!' % mask.nick)


### PR DESCRIPTION
This is not a patch to fully implement and integrate the specification for IRCv3.2 tags. It just adds basic support to accept and parse messages that happen to contain tags. With this patch it is possible to manually send CAP REQ messages and successfully get tagdata afterwards.
For IRCv3.2 tag specification see http://ircv3.net/specs/core/message-tags-3.2.html

~~Sadly, this brings some minor backwards-incompatibilities, since the additional field "tags" is added to all events, including some JOIN events that did not take kwargs before.~~
Edit: See comments below.
I suggest always including kwargs in all events anyway, to be able to add more fields in the future without such problems.

An example on how this enables the use of tags for twitch irc:
 - Sent CAP REQ messages before joining any channels
```
    def server_ready(self):
        """triggered after the server sent the MOTD (require core plugin)"""
        self.bot.send_line("CAP REQ :twitch.tv/tags")
```

 - extract the now available tags from the kwargs and use them however you like
```
    @irc3.event(irc3.rfc.PRIVMSG)
    def on_privmsg(self, data=None, tags=None, target=None, **kw):
        tagdict = irc3.tags.decode(tags)
        print(tagdict)
```