### PR TITLE
Ensure we send the PING and PONG data as trailing

### DIFF
--- a/irc3/plugins/core.py
+++ b/irc3/plugins/core.py
@@ -83,12 +83,12 @@ class Core(object):
             self.ping_handle.cancel()
         self.ping_handle = self.bot.loop.call_later(
             self.timeout - self.max_lag, self.bot.send,
-            'PING %s' % int(self.bot.loop.time()))
+            'PING :%s' % int(self.bot.loop.time()))
 
     @event(rfc.PING)
     def ping(self, data):
         """PING reply"""
-        self.bot.send('PONG ' + data)
+        self.bot.send('PONG :' + data)
         self.pong(event='PING', data=data)
 
     @event(rfc.NEW_NICK)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -97,7 +97,7 @@ class TestBot(BotTestCase):
         bot = self.callFTU()
         bot.include('irc3.plugins.core')
         bot.dispatch('PING :youhou')
-        self.assertSent(['PONG youhou'])
+        self.assertSent(['PONG :youhou'])
 
     def test_nick(self):
         bot = self.callFTU()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -151,7 +151,7 @@ class TestCommands(BotTestCase):
                         'irc3.debug',
                     ])
         bot.dispatch(':bar!user@host PRIVMSG #chan :!reconnect')
-        self.assertSent(['PING 10'])
+        self.assertSent(['PING :10'])
 
     def test_antiflood(self):
         bot = self.callFTU(**{self.name: dict(antiflood=True)})


### PR DESCRIPTION
Some servers send the a PING argument with spaces so we need to ensure we send the response as a trailing arg. Additionally, I changed the PING to use the trailing arg as well, just in case.