### PR TITLE
Added tagdict property to IrcString, improved tag parsing

### DIFF
--- a/irc3/utils.py
+++ b/irc3/utils.py
@@ -2,6 +2,7 @@
 from unicodedata import normalize
 from .compat import configparser
 from .compat import asyncio
+from . import tags
 import importlib
 import functools
 import logging
@@ -104,6 +105,24 @@ class IrcString(BaseString):
             True
         """
         return not (self.is_server or self.is_channel)
+
+    @property
+    def tagdict(self):
+        """return a dict converted from this string interpreted as a tag-string
+
+        .. code-block:: py
+
+            >>> from pprint import pprint
+            >>> dict_ = IrcString('aaa=bbb;ccc;example.com/ddd=eee').tagdict
+            >>> pprint({str(k): str(v) for k, v in dict_.items()})
+            {'aaa': 'bbb', 'ccc': 'None', 'example.com/ddd': 'eee'}
+        """
+        if not hasattr(self, "_tagdict"):
+            try:
+                self._tagdict = tags.decode(self)
+            except ValueError:
+                self._tagdict = {}
+        return self._tagdict
 
 
 STRIPPED_CHARS = '\t '


### PR DESCRIPTION
Just some sugar to make accessing IRCv3.2 tags a little more intuitive, mostly to avoid the import of "irc3.tags". I should have added something like this in the first pull request, but I didn't, so that's that.

Before (still valid):
```
@irc3.event(irc3.rfc.PRIVMSG)
def on_privmsg(self, tags=None, **kw):
    tagdict = irc3.tags.decode(tags)
    print(tagdict)
```

After:
```
@irc3.event(irc3.rfc.PRIVMSG)
def on_privmsg(self, tags=None, **kw):
    tagdict = tags.tagdict if tags else {}
    print(tagdict)
```

Also added some error checking for decoding tags, since people could potentionally try to parse every IrcString as tags now.