### PR TITLE
Allow double-pound channels in config.ini via text replace

### DIFF
--- a/irc3/plugins/autojoins.py
+++ b/irc3/plugins/autojoins.py
@@ -9,6 +9,9 @@ __doc__ = '''
 Auto join channels. The bot will retry to join when kicked and will retry to
 join each 30s when an error occurs.
 
+To add a "double-pound" (``##``) channel from ``config.ini``, use
+commas (``,,``) instead of pounds.
+
 ..
     >>> from irc3.testing import IrcBot
 
@@ -28,7 +31,8 @@ class AutoJoins(object):
 
     def __init__(self, bot):
         self.bot = bot
-        self.channels = utils.as_list(self.bot.config.get('autojoins', []))
+        L = utils.as_list(self.bot.config.get('autojoins', []))
+        self.channels = [ch.replace(',', '#') for ch in L]
         self.handles = {}
         self.timeout = 240
 

--- a/irc3/template/config.ini
+++ b/irc3/template/config.ini
@@ -15,6 +15,9 @@ includes =
     {nick}_plugin
 
 # the bot will join #{nick}_channel
+#
+# commas (,) will be replaced with pounds (#) when parsed
+# e.g. ,,my_channel -> ##my_channel
 autojoins =
     {nick}_channel
 

--- a/tests/test_autojoins.py
+++ b/tests/test_autojoins.py
@@ -62,3 +62,10 @@ class TestAutojoin(BotTestCase):
         self.assertNotIn('#foo', plugin.handles)
 
         bot.notify('connection_lost')
+
+    def test_poundescape(self):
+        bot = self.callFTU(autojoins=[',foo', ',,bar'])
+        bot.notify('connection_made')
+
+        bot.dispatch(':hobana.freenode.net 376 irc3 :End of /MOTD command.')
+        self.assertSent(['JOIN #foo', 'JOIN ##bar'])


### PR DESCRIPTION
Hi, not sure if this is the best way to address this issue. Let me know what you think:

Commas are not valid in channel names [1], so it looks like this is a good way
to address this issue without changing ConfigParser's comment_prefixes or
rolling another parser.

1: https://tools.ietf.org/html/rfc2812#section-1.3