### PR TITLE
add + to WEIRD_CHARS

### DIFF
--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -133,7 +133,7 @@ Available options
 
 '''
 
-WEIRD_CHARS = '$^|.*?'
+WEIRD_CHARS = '$^|.*?+'
 
 
 class free_policy(object):


### PR DESCRIPTION
My bot actually uses + as prefix.

Though, why not use `re.escape(...)` instead?