### PR TITLE
Realname belongs to the end and "user" is missing

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -152,7 +152,7 @@ class IrcBot(base.IrcObject):
             if self.config.get('password'):
                 self._send('PASS {password}'.format(**self.config))
             self.send((
-                'USER {realname} {host} {host} :{userinfo}\r\n'
+                'USER {user} 0 * :{realname}\r\n'
                 'NICK {nick}\r\n'
             ).format(**self.config))
             self.notify('connection_made')

--- a/irc3/template/config.ini
+++ b/irc3/template/config.ini
@@ -1,5 +1,6 @@
 [bot]
 nick = {nick}
+user = {nick}
 realname = {nick}
 
 host = localhost


### PR DESCRIPTION
RFC puts realname at the end, because it can contain whitespaces.
https://tools.ietf.org/html/rfc2812#section-3.1.3

Also, there is currently no way to define a custom user.

The second and third parameter of USER is usually ignored by servers
if it comes from a client.

Don't know where "userinfo" came from, so I just removed it here.