### PR TITLE
Fix a typo in the Async docs

### DIFF
--- a/irc3/plugins/async.py
+++ b/irc3/plugins/async.py
@@ -30,7 +30,7 @@ Then you're able to use it in a plugin:
 
         def __init__(self, bot):
             self.bot = bot
-            self.whois = Whois(context)
+            self.whois = Whois(bot)
 
         def do_whois(self):
             # remember {nick} in the regexp? Here it is


### PR DESCRIPTION
The variable name `context` was used but the bot was being passed in as `bot`.