### PR TITLE
Add autojoin_delay configuration option

### DIFF
--- a/irc3/plugins/autojoins.py
+++ b/irc3/plugins/autojoins.py
@@ -29,8 +29,12 @@ class AutoJoins(object):
     def __init__(self, bot):
         self.bot = bot
         self.channels = utils.as_list(self.bot.config.get('autojoins', []))
+        self.delay = self.bot.config.get('autojoin_delay', 0)
         self.handles = {}
         self.timeout = 240
+        if not isinstance(self.delay, (int, float)):  # pragma: no cover
+            self.bot.log.error('Wrong autojoin_delay value: %r', self.delay)
+            self.delay = 0
 
     def connection_lost(self):  # pragma: no cover
         for timeout, handle in self.handles.values():
@@ -38,7 +42,10 @@ class AutoJoins(object):
         self.handles = {}
 
     def server_ready(self):
-        self.join()
+        if not self.delay:
+            self.join()
+        else:
+            self.bot.loop.call_later(self.delay, self.join)
 
     def join(self, channel=None):
         if channel is None:

--- a/irc3/template/config.ini
+++ b/irc3/template/config.ini
@@ -21,6 +21,9 @@ includes =
 autojoins =
     {hash}{nick}_channel
 
+# Autojoin delay, disabled by default
+# float or int value
+# autojoin_delay = 3.1
 # The maximum amount of lines irc3 sends at once.
 # Default to 4
 # flood_burst = 10

--- a/tests/test_autojoins.py
+++ b/tests/test_autojoins.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from irc3.testing import BotTestCase
+from irc3.testing import BotTestCase, MagicMock
 from irc3.plugins.autojoins import AutoJoins
 
 
@@ -62,3 +62,10 @@ class TestAutojoin(BotTestCase):
         self.assertNotIn('#foo', plugin.handles)
 
         bot.notify('connection_lost')
+
+    def test_autojoin_delay(self):
+        bot = self.callFTU(autojoins=['#foo'], autojoin_delay=3)
+        bot.loop.call_later = MagicMock()
+        bot.notify('connection_made')
+        bot.dispatch(':hobana.freenode.net 422 irc3 :No MOTD.')
+        self.assertTrue(bot.loop.call_later.called)


### PR DESCRIPTION
Sometimes it's useful to delay autojoin. For example: if you want to hide your host and apply special modes before join or for authorization before join. This can be better accomplished by calling join after receiving event that all required tasks like authorization or changing mode were successfully done, but since this is highly network dependent thing, it is good to have autojoin delay.
Many popular irc clients support autojoin delay: [weechat](https://weechat.org/files/doc/weechat_faq.en.html#irc_sasl), [mIRC](http://en.wikichip.org/wiki/mirc/commands/autojoin), [hexchat](https://github.com/hexchat/hexchat/blob/c874a9525c9b66f1d5ddcf6c4107d046eba7e2c5/src/common/cfgfiles.c#L510), xchat and many others.

This patch adds configure option `autojoin_delay` that delays joining  for configured amount of seconds.