### PR TITLE
Fix doctest in fifo plugin

### DIFF
--- a/irc3/plugins/fifo.py
+++ b/irc3/plugins/fifo.py
@@ -34,7 +34,7 @@ Usage::
 When your bot will join a channel it will create a fifo::
 
     >>> bot.test(':irc3!user@host JOIN #channel')
-    >>> print(os.listdir('/tmp/run/irc3'))
+    >>> print(sorted(os.listdir('/tmp/run/irc3')))
     [':raw', 'channel']
 
 You'll be able to print stuff to a channel from a shell::


### PR DESCRIPTION
`listdir` have no guarantees about order of items. This causes an exceptions during execution of unit tests under some versions of python. Using `sorted` function solves this issue.