### PR TITLE
Add quakenet plugin

### DIFF
--- a/docs/plugins/quakenet.rst
+++ b/docs/plugins/quakenet.rst
@@ -1,0 +1,2 @@
+.. automodule:: irc3.plugins.quakenet
+

--- a/irc3/plugins/quakenet.py
+++ b/irc3/plugins/quakenet.py
@@ -1,0 +1,122 @@
+import hashlib
+import hmac
+import irc3
+
+__doc__ = '''
+=================================================
+:mod:`irc3.plugins.quakenet` QuakeNet authorization
+=================================================
+
+Plugin supports both simple and
+`challenge based <https://www.quakenet.org/development/challengeauth>`_
+authorization.  Challenge based auth is used by default, since it is more
+secure than simple.  Also, plugin can hide your IP after authorization
+by applying ``+x`` mode.
+
+..
+    >>> from irc3.testing import IrcBot
+    >>> from irc3.testing import ini2config
+
+Usage::
+
+    >>> config = ini2config("""
+    ... [bot]
+    ... includes =
+    ...     irc3.plugins.quakenet
+    ... [quakenet]
+    ... user = login
+    ... password = passw
+    ... # optional, false by default
+    ... hidehost = true
+    ... # optional, true by default
+    ... challenge_auth = true
+    ... """)
+    >>> bot = IrcBot(**config)
+
+'''
+
+Q_NICK = "Q@CServe.quakenet.org"
+CHALLENGE_PATTERN = ("^:Q![a-zA-Z]+@CServe.quakenet.org NOTICE "
+                     "(?P<nick>\S+) :CHALLENGE (?P<challenge>[a-z0-9]+) ")
+
+
+def get_digest(digest):
+    if not isinstance(digest, str):  # pragma: no cover
+        raise ValueError("Wrong type of digest")
+
+    digest = digest.lower()
+    if digest in ("sha256", "sha1", "md5"):
+        return getattr(hashlib, digest)
+    else:  # pragma: no cover
+        raise ValueError("Wrong value for digest")
+
+
+def challenge_auth(username, password, challenge, lower, digest='sha256'):
+    """Calculates quakenet's challenge auth hash
+
+    .. code-block:: python
+
+        >>> challenge_auth("mooking", "0000000000",
+        ...     "12345678901234567890123456789012", str.lower, "md5")
+        '2ed1a1f1d2cd5487d2e18f27213286b9'
+    """
+    def hdig(x):
+        return fdigest(x).hexdigest()
+
+    fdigest = get_digest(digest)
+    luser = lower(username)
+    tpass = password[:10].encode("ascii")
+    hvalue = hdig("{0}:{1}".format(luser, hdig(tpass)).encode("ascii"))
+    bhvalue = hvalue.encode("ascii")
+    bchallenge = challenge.encode("ascii")
+    return hmac.HMAC(bhvalue, bchallenge, digestmod=fdigest).hexdigest()
+
+
+@irc3.plugin
+class QuakeNet(object):
+
+    requires = [
+        'irc3.plugins.core',
+        'irc3.plugins.casefold'
+    ]
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = bot.config.get("quakenet", {})
+        self.user = self.config.get('user', None)
+        self.password = self.config.get('password', None)
+        self.hidehost = bool(self.config.get('hidehost', False))
+        # secure by default
+        self.challenge_auth = bool(self.config.get('challenge_auth', True))
+        self.pending_auth = False
+
+    def server_ready(self):
+        self.auth()
+
+    def auth(self):
+        if self.user and self.password:
+            if self.challenge_auth:
+                self.bot.log.info("Requesting challenge")
+                self.bot.privmsg(Q_NICK, 'CHALLENGE')
+                self.pending_auth = True
+            else:
+                self.bot.log.info("Sending login information to QuakeNet")
+                self.bot.send_line("AUTH {user} {password}".format(
+                                   user=self.user, password=self.password))
+                self.after_auth()
+
+    def after_auth(self):
+        if self.hidehost:
+            self.bot.mode(self.bot.nick, "+x")
+
+    @irc3.event(CHALLENGE_PATTERN)
+    def get_challenge(self, nick, challenge, **kwargs):
+        if nick == self.bot.nick and self.pending_auth:
+            hauth = challenge_auth(self.user, self.password, challenge,
+                                   self.bot.casefold, "sha256")
+            cmd = 'CHALLENGEAUTH {user} {response} {algo}'. \
+                format(user=self.user, response=hauth, algo="HMAC-SHA-256")
+
+            self.bot.log.info("Performing challenge authorization on QuakeNet")
+            self.bot.privmsg(Q_NICK, cmd)
+            self.after_auth()

--- a/tests/test_quakenet.py
+++ b/tests/test_quakenet.py
@@ -1,0 +1,62 @@
+from irc3.testing import BotTestCase
+from irc3.plugins import quakenet
+
+
+class TestQuakenet(BotTestCase):
+
+    config = dict(
+            includes=['irc3.plugins.quakenet'],
+            quakenet=dict(user="bot", password="password", hidehost=True,
+                          challenge_auth=False))
+
+    def test_challenge(self):
+        # Test vectors taken from:
+        # https://www.quakenet.org/development/challengeauth
+        user1 = ("mooking", "0000000000")
+        user2 = ("fishking", "ZZZZZZZZZZ")
+        challenge = "12345678901234567890123456789012"
+
+        def digest(user, algo):
+            return quakenet.challenge_auth(user[0], user[1], challenge,
+                                           str.lower, algo)
+
+        res1 = digest(user1, "md5")
+        self.assertEquals(res1, '2ed1a1f1d2cd5487d2e18f27213286b9')
+
+        res2 = digest(user2, "md5")
+        self.assertEquals(res2, '8990cb478218b6c0063daf08dd7e1a72')
+
+        res3 = digest(user1, "sha1")
+        self.assertEquals(res3, 'd0328d41426bd2ace183467ce0a6305445e3d497')
+
+        res4 = digest(user2, "sha1")
+        self.assertEquals(res4, '4de3f1c86dd0f59da44852d507e193c339c4b108')
+
+        res5 = digest(user1, "sha256")
+        self.assertEquals(res5, 'f6eced34321a69c270472d06c50e959c48e9fd323'
+                          'b2c5d3194f44b50a118a7ea')
+
+        res6 = digest(user2, "sha256")
+        self.assertEquals(res6, '504056d53b2fc4fd783dc4f086dabc59f845d201e650'
+                          'b96dfa95dacc8cac2892')
+
+    def test_simple_auth(self):
+        bot = self.callFTU()
+        bot.notify('connection_made')
+        bot.dispatch(':azubu.uk.quakenet.org 376 irc3 :End of /MOTD command.')
+        self.assertSent(['AUTH bot password', "MODE irc3 +x"])
+
+    def test_challenge_auth(self):
+        quakenet_config = dict(self.config["quakenet"])
+        quakenet_config["challenge_auth"] = True
+        bot = self.callFTU(quakenet=quakenet_config)
+        bot.notify('connection_made')
+        bot.dispatch(':azubu.uk.quakenet.org 376 irc3 :End of /MOTD command.')
+        self.assertSent(['PRIVMSG Q@CServe.quakenet.org :CHALLENGE'])
+        bot.dispatch(":Q!TheQBot@CServe.quakenet.org NOTICE irc3 "
+                     ":CHALLENGE 12345678901234567890123456789012 "
+                     "HMAC-MD5 HMAC-SHA-1 HMAC-SHA-256 LEGACY-MD5")
+
+        self.assertSent(["PRIVMSG Q@CServe.quakenet.org "
+                         ":CHALLENGEAUTH bot 76abae4fbbcf56b7296c1477e7d378a"
+                         "2590a147cf92afa5a952b321491c51bc6 HMAC-SHA-256"])


### PR DESCRIPTION
This plugin handles authorization on [QuakeNet IRC network](https://en.wikipedia.org/wiki/QuakeNet). It supports both [simple](https://www.quakenet.org/help/q-commands/auth) and [challenge based auth](https://www.quakenet.org/development/challengeauth). Challenge based authorization is used by default. 
Also, it can [hide your hostname](https://www.quakenet.org/help/security/how-can-i-hide-my-hostname-on-quakenet) after authorization.
