### PR TITLE
Couple improvements to fifo plugin

### DIFF
--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -1,0 +1,37 @@
+from irc3.testing import BotTestCase, MagicMock
+from irc3.plugins.fifo import Fifo
+
+
+class TestFifo(BotTestCase):
+
+    config = {
+        "includes": ['irc3.plugins.fifo'],
+        "irc3.plugins.fifo": {"runpath": "/tmp/run/irc3"}
+    }
+
+    def test_fifo_fake_event_loop(self):
+        bot = self.callFTU()
+        plugin = bot.get_plugin(Fifo)
+        plugin.loop = MagicMock()
+        bot.test(':irc3!user@host JOIN #channel')
+        channel_fd = plugin.fifos["#channel"]
+
+        with open("/tmp/run/irc3/channel", "wb", 0) as f:
+            f.write(b"test1\n")
+            plugin.watch_fd(channel_fd, "#chanel")
+            self.assertSent(['PRIVMSG #chanel :test1'])
+
+            f.write(b"test2\r\n")
+            plugin.watch_fd(channel_fd, "#chanel")
+            self.assertSent(['PRIVMSG #chanel :test2'])
+
+            f.write(b"test3\r\ntest4\n")
+            plugin.watch_fd(channel_fd, "#chanel")
+            self.assertSent(['PRIVMSG #chanel :test3',
+                             'PRIVMSG #chanel :test4'])
+
+            for char in b"test5\n":
+                f.write(bytes([char]))
+                plugin.watch_fd(channel_fd, "#chanel")
+
+            self.assertSent(['PRIVMSG #chanel :test5'])


### PR DESCRIPTION
Original code of fifo plugin have couple issues. First of all, it is using polling with 0.2 seconds interval for checking or FIFO available for read. For one channel it will produce 5 system calls (1 / 0.2) per second. It looks like small amount of work, but let's imagine that bot joins to 19 channels. This means that it will execute 100 system calls per second (19 channels + 1 for :raw, 20 * 5 = 100). More channels will cause more load. Instead of polling I'm using event driven approach, handler are called only when new data available in fifo.

There are also another issue, POSIX recommends using  `O_NONBLOCK` over `O_NDELAY`. Here's one of explanations [why](https://mail.python.org/pipermail/python-list/1999-May/013687.html). Same recommendations came from  [Richard Stevens book](https://en.wikipedia.org/wiki/Advanced_Programming_in_the_Unix_Environment).

Another thing, that is handled in different way in my version, is handling of partial input. Python's `readline` isn't designed for non-blocking files and because of this it isn't handles partial input. For example:
```bash
    #!/bin/bash
    echo -n "t" > /tmp/irc3/channel
    echo -n "e" > /tmp/irc3/channel
    echo -n "s" > /tmp/irc3/channel
    echo "t" > /tmp/irc3/channel
```
or similar python code
```python
    #!/bin/env python
    # should be opened without buffering
    with open("/tmp/irc3/channel", "wb", 0) as f:
        for char in b"test\n":
            f.write(bytes([char]))
```

This will send couple lines to IRC instead of one. My version will send only one line in this case, but this approach have some drawbacks too. Major drawback is that it requires saving input values to memory and can cause memory leaking in case of very large lines. To prevent this, I limited maximum size of line, if line are longer it just delivered to IRC without waiting other parts of line.

There are also one issue which I didn't fix here. Suppose bot joins two channels: `#python` and `##python`. They both will use same FIFO file. Most of file systems on *nix like OSs isn't restrict these symbols `#&+`. So, I think, it should be safe to remove `.strip('#&+')` from code. Also, [weechat logger](https://weechat.org/files/doc/stable/weechat_user.en.html#logger_filenames_masks) by default create files with these chars for channels. 