### PR TITLE
Fix issue with no coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,9 @@ include =
     */irc3/*/*.py
 omit =
     conftest.py
-    */tests*
-    */docs/conf.py
+    .tox/*
+    tests/*
+    docs/conf.py
     */examples/social*
     */examples/mycrons*
     */examples/mycommands*
@@ -19,7 +20,6 @@ omit =
     */lib/python*
     */lib-python*
     */lib_pypy*
-    */src*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
On one of my working machines I had an interesting issue.  Coverage wasn't generating report for this project. Result was like this: 

```
Coverage.py warning: No data was collected.
py34 runtests: commands[3] | coverage report -m
Name    Stmts   Miss  Cover   Missing
-------------------------------------
No data to report.
ERROR: InvocationError: '/home/slava/src/irc3/.tox/py34/bin/coverage report -m'
___________________________________ summary ____________________________________
ERROR:   py34: commands failed

```
After some time, I found that issue was caused by `*/src*` rule in `.coveragerc` file. This happened because I used `~/src/irc3/` folder and any file was matching to that rule.  Same issue might be caused by `*/tests*` rule too.