### PR TITLE
Add autocommand module

### DIFF
--- a/docs/plugins/autocommand.rst
+++ b/docs/plugins/autocommand.rst
@@ -1,0 +1,1 @@
+.. automodule:: irc3.plugins.autocommand

--- a/irc3/plugins/autocommand.py
+++ b/irc3/plugins/autocommand.py
@@ -1,0 +1,76 @@
+import irc3
+from irc3 import utils, asyncio
+import re
+
+__doc__ = '''
+==================================================
+:mod:`irc3.plugins.autocommand` Autocommand plugin
+==================================================
+
+Plugin allows send IRC commands after connecting to server. This could
+be usable for authorization, cloaking, requesting invite to invite only channel
+and other use cases. Also, plugin allows to set delay between IRC commands via
+``/sleep`` command.
+
+..
+    >>> from irc3.testing import IrcBot
+
+Usage::
+
+This example will authorize you in FreeNode IRC network.
+
+    >>> bot = IrcBot(autocommand=['PRIVMSG NickServ IDENTIFY nick password'])
+    >>> bot.include('irc3.plugins.autocommand')
+
+Here's another, more complicated example.
+
+    >>> bot = IrcBot(autocommand=[
+    ...     'PRIVMSG Q AUTH user password', 'MODE {nick} +x', '/sleep 2',
+    ...     'PRIVMSG Q INVITE #inviteonly'
+    ... ])
+    >>> bot.include('irc3.plugins.autocommand')
+
+It will authorize bot in QuakeNet IRC network, cloak and then after 3 seconds
+delay will request invite to ``#inviteonly`` channel.
+'''
+
+
+@irc3.plugin
+class AutoCommand:
+
+    requires = [
+        'irc3.plugins.core',
+    ]
+
+    SLEEP_RE = re.compile(r"^/sleep\s+(?P<time>[\d\.]+)\s*$", re.IGNORECASE)
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.commands = utils.as_list(self.bot.config.get('commands', []))
+
+    def server_ready(self):
+        # async deprecated since 3.4.4
+        asyncio.async(self.execute_commands(), loop=self.bot.loop)
+
+    @asyncio.coroutine
+    def execute_commands(self):
+        for command in self.commands:
+            yield from self.process_command(command)
+
+    @asyncio.coroutine
+    def process_command(self, command):
+        if not command:
+            return
+
+        if command.startswith('/'):
+            sleep_m = self.SLEEP_RE.match(command)
+            if sleep_m is not None:
+                try:
+                    val = float(sleep_m.groupdict()['time'])
+                except ValueError:
+                    self.bot.log.error("Wrong /sleep value")
+                else:
+                    yield from asyncio.sleep(val, loop=self.bot.loop)
+        else:
+            cmd = command.format(nick=self.bot.nick)
+            self.bot.send_line(cmd)

--- a/tests/test_autocommand.py
+++ b/tests/test_autocommand.py
@@ -1,4 +1,5 @@
 from irc3.testing import BotTestCase, patch
+from irc3.plugins.autocommand import AutoCommand, SleepCommand
 
 
 class TestAutoCommand(BotTestCase):
@@ -16,12 +17,43 @@ class TestAutoCommand(BotTestCase):
             bot = self.callFTU(commands=['AUTH user pass', '/slEep  3',
                                          'MODE {nick} +x'])
             bot.notify('connection_made')
-            bot.dispatch(':host.freenode.net 376 irc3 :End of /MOTD command.')
+            bot.dispatch(':node.net 376 irc3 :End of /MOTD command.')
             self.assertSent(['AUTH user pass', 'MODE irc3 +x'])
             sleep.assert_called_once_with(3, loop=bot.loop)
-            # test bad arguments too
-            bot2 = self.callFTU(commands=[None, '/sleep 3.4.5', '/sleep bad',
-                                          'TEST SENT'])
-            bot2.notify('connection_made')
-            bot2.dispatch(':host.freenode.net 376 irc3 :End of /MOTD command.')
-            self.assertSent(['TEST SENT'])
+
+            with self.assertRaises(ValueError):
+                # test bad arguments too
+                bot2 = self.callFTU(commands=[
+                        None, '/sleep 3.4.5', '/sleep bad', 'TEST SENT'])
+                bot2.notify('connection_made')
+                bot2.dispatch(':node.net 376 irc3 '':End of /MOTD command.')
+                self.assertSent(['TEST SENT'])
+
+    def test_autocommand_validation(self):
+        sleep = AutoCommand.parse_command("/sleeP 3")
+        self.assertIsInstance(sleep, SleepCommand)
+        self.assertEqual(sleep.time, 3)
+        # test unknown command
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/sleepwhile")
+
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/bad")
+
+        # test error on multiple arguments
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/sleep 3.2 two 3")
+
+        # test sleep without arguments
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/sleep")
+
+        # test sleep with wrong aruments
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/sleep bad")
+
+        with self.assertRaises(ValueError):
+            AutoCommand.parse_command("/sleep 3.4.5")
+
+        with self.assertRaises(TypeError):
+            SleepCommand("bad")

--- a/tests/test_autocommand.py
+++ b/tests/test_autocommand.py
@@ -1,0 +1,27 @@
+from irc3.testing import BotTestCase, patch
+
+
+class TestAutoCommand(BotTestCase):
+
+    config = dict(includes=['irc3.plugins.autocommand'])
+
+    @patch("irc3.asyncio.sleep")
+    def test_autocommand(self, sleep):
+        def new_async(coro, *args, **kw):
+            for res in coro:
+                pass  # do nothing
+
+        with patch('irc3.asyncio.async', new_async):
+            # sleep typed in mixed case to test that work with different cases
+            bot = self.callFTU(commands=['AUTH user pass', '/slEep  3',
+                                         'MODE {nick} +x'])
+            bot.notify('connection_made')
+            bot.dispatch(':host.freenode.net 376 irc3 :End of /MOTD command.')
+            self.assertSent(['AUTH user pass', 'MODE irc3 +x'])
+            sleep.assert_called_once_with(3, loop=bot.loop)
+            # test bad arguments too
+            bot2 = self.callFTU(commands=[None, '/sleep 3.4.5', '/sleep bad',
+                                          'TEST SENT'])
+            bot2.notify('connection_made')
+            bot2.dispatch(':host.freenode.net 376 irc3 :End of /MOTD command.')
+            self.assertSent(['TEST SENT'])


### PR DESCRIPTION
Hi, I made plugin about what we were talking in issue #99. I implemented `/sleep` command with slash prefix, because there are some possibility that some IRC might have such command (very small but still possible). Also, in case of need introducing other specially handled commands, slash prefix will be a sign of such commands. 