### PR TITLE
Run tests on calling setup.py test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,4 @@ exclude=bootstrap.py,./irc3/compat.py,./.tox/*,./src/*,./docs*
 
 [aliases]
 dev = develop easy_install irc3[test]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ test_requires = [
     'twitter',
     'aiocron',
     'redis',
+    'pytest'
 ]
 
 install_requires_py33 = [
@@ -53,6 +54,8 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
+    tests_require=test_requires,
+    setup_requires=["pytest-runner"],
     extras_require={
         ':python_version=="3.3"': install_requires_py33,
         'test': test_requires,


### PR DESCRIPTION
This commit will allow executing tests via `python setup.py test` command. Also this command will install all necessary packages for tests.