### PR TITLE
Fix ssl context creation

### DIFF
--- a/irc3/base.py
+++ b/irc3/base.py
@@ -295,9 +295,9 @@ class IrcObject(object):
                 return True
             else:
                 if self.server:
-                    context = create_default_context(ssl.Purpose.SERVER_AUTH)
-                else:
                     context = create_default_context(ssl.Purpose.CLIENT_AUTH)
+                else:
+                    context = create_default_context(ssl.Purpose.SERVER_AUTH)
                 verify_mode = self.config.ssl_verify
                 if verify_mode is not False:
                     if not isinstance(verify_mode, int):


### PR DESCRIPTION
As per https://docs.python.org/3/library/ssl.html#examples and https://docs.python.org/3/library/ssl.html#ssl.Purpose.SERVER_AUTH, the Purpose is supposed to mean the type of target we are connecting to, not the type of client/server we are.
