### PR TITLE
Add support for ujson to storage plugin

### DIFF
--- a/irc3/plugins/storage.py
+++ b/irc3/plugins/storage.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
-import json
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+    
 import irc3
 import shelve
 __doc__ = '''

--- a/irc3/plugins/storage.py
+++ b/irc3/plugins/storage.py
@@ -5,7 +5,7 @@ try:
     import ujson as json
 except ImportError:
     import json
-    
+
 import irc3
 import shelve
 __doc__ = '''


### PR DESCRIPTION
This commit adds automatic support for [ujson](https://pypi.python.org/pypi/ujson), a faster json implementation than the Python default. If ujson is installed in the user's site packages, it will automatically be imported as `json`, so no other code changes are necessary to benefit from it.