### PR TITLE
[autocommand] Rename and document config-directive

### DIFF
--- a/irc3/plugins/autocommand.py
+++ b/irc3/plugins/autocommand.py
@@ -7,17 +7,17 @@ __doc__ = '''
 :mod:`irc3.plugins.autocommand` Autocommand plugin
 ==================================================
 
-Plugin allows send IRC commands after connecting to server. This could
-be usable for authorization, cloaking, requesting invite to invite only channel
-and other use cases. Also, plugin allows to set delay between IRC commands via
-``/sleep`` command.
+This plugin allows to send IRC commands to the server after connecting.
+This could be usable for authorization, cloaking, requesting invite to invite
+only channel and other use cases.
+It also allows to set delays between IRC commands via the ``/sleep`` command.
 
 ..
     >>> from irc3.testing import IrcBot
 
 Usage::
 
-This example will authorize you in FreeNode IRC network.
+This example will authorize on Freenode.
 
     >>> bot = IrcBot(autocommands=['PRIVMSG NickServ IDENTIFY nick password'])
     >>> bot.include('irc3.plugins.autocommand')
@@ -30,8 +30,8 @@ Here's another, more complicated example.
     ... ])
     >>> bot.include('irc3.plugins.autocommand')
 
-It will authorize bot in QuakeNet IRC network, cloak and then after 3 seconds
-delay will request invite to ``#inviteonly`` channel.
+It will authorize on QuakeNet, cloak and request an invite to ``#inviteonly``
+after a 2 second delay.
 '''
 
 

--- a/irc3/plugins/autocommand.py
+++ b/irc3/plugins/autocommand.py
@@ -12,6 +12,10 @@ This could be usable for authorization, cloaking, requesting invite to invite
 only channel and other use cases.
 It also allows to set delays between IRC commands via the ``/sleep`` command.
 
+..
+    >>> from irc3.testing import IrcBot
+    >>> from irc3.testing import ini2config
+
 Usage::
 
 This example will authorize on Freenode:

--- a/irc3/plugins/autocommand.py
+++ b/irc3/plugins/autocommand.py
@@ -12,23 +12,34 @@ This could be usable for authorization, cloaking, requesting invite to invite
 only channel and other use cases.
 It also allows to set delays between IRC commands via the ``/sleep`` command.
 
-..
-    >>> from irc3.testing import IrcBot
-
 Usage::
 
-This example will authorize on Freenode.
+This example will authorize on Freenode:
 
-    >>> bot = IrcBot(autocommands=['PRIVMSG NickServ IDENTIFY nick password'])
-    >>> bot.include('irc3.plugins.autocommand')
+    >>> config = ini2config("""
+    ... [bot]
+    ... includes =
+    ...     irc3.plugins.autocommand
+    ...
+    ... autocommands =
+    ...     PRIVMSG NickServ IDENTIFY nick password
+    ... """)
+    >>> bot = IrcBot(**config)
 
-Here's another, more complicated example.
+Here's another, more complicated example:
 
-    >>> bot = IrcBot(autocommands=[
-    ...     'AUTH user password', 'MODE {nick} +x', '/sleep 2',
-    ...     'PRIVMSG Q INVITE #inviteonly'
-    ... ])
-    >>> bot.include('irc3.plugins.autocommand')
+    >>> config = ini2config("""
+    ... [bot]
+    ... includes =
+    ...     irc3.plugins.autocommand
+    ...
+    ... autocommands =
+    ...     AUTH user password
+    ...     MODE {nick} +x
+    ...     /sleep 2
+    ...     PRIVMSG Q INVITE #inviteonly
+    ... """)
+    >>> bot = IrcBot(**config)
 
 It will authorize on QuakeNet, cloak and request an invite to ``#inviteonly``
 after a 2 second delay.

--- a/irc3/plugins/autocommand.py
+++ b/irc3/plugins/autocommand.py
@@ -19,12 +19,12 @@ Usage::
 
 This example will authorize you in FreeNode IRC network.
 
-    >>> bot = IrcBot(autocommand=['PRIVMSG NickServ IDENTIFY nick password'])
+    >>> bot = IrcBot(autocommands=['PRIVMSG NickServ IDENTIFY nick password'])
     >>> bot.include('irc3.plugins.autocommand')
 
 Here's another, more complicated example.
 
-    >>> bot = IrcBot(autocommand=[
+    >>> bot = IrcBot(autocommands=[
     ...     'AUTH user password', 'MODE {nick} +x', '/sleep 2',
     ...     'PRIVMSG Q INVITE #inviteonly'
     ... ])
@@ -88,7 +88,7 @@ class AutoCommand:
 
     def __init__(self, bot):
         self.bot = bot
-        cmds = utils.as_list(self.bot.config.get('commands', []))
+        cmds = utils.as_list(self.bot.config.get('autocommands', []))
         self.commands = [self.parse_command(cmd) for cmd in cmds]
 
     @staticmethod

--- a/tests/test_autocommand.py
+++ b/tests/test_autocommand.py
@@ -14,8 +14,8 @@ class TestAutoCommand(BotTestCase):
 
         with patch('irc3.asyncio.async', new_async):
             # sleep typed in mixed case to test that work with different cases
-            bot = self.callFTU(commands=['AUTH user pass', '/slEep  3',
-                                         'MODE {nick} +x'])
+            bot = self.callFTU(autocommands=['AUTH user pass', '/slEep  3',
+                                             'MODE {nick} +x'])
             bot.notify('connection_made')
             bot.dispatch(':node.net 376 irc3 :End of /MOTD command.')
             self.assertSent(['AUTH user pass', 'MODE irc3 +x'])
@@ -23,7 +23,7 @@ class TestAutoCommand(BotTestCase):
 
             with self.assertRaises(ValueError):
                 # test bad arguments too
-                bot2 = self.callFTU(commands=[
+                bot2 = self.callFTU(autocommands=[
                         None, '/sleep 3.4.5', '/sleep bad', 'TEST SENT'])
                 bot2.notify('connection_made')
                 bot2.dispatch(':node.net 376 irc3 '':End of /MOTD command.')


### PR DESCRIPTION
Renamed config-directive to `autocommands` and reworded documentation a little bit.