### PR TITLE
commands: only consider space as whitespace

### DIFF
--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -268,7 +268,7 @@ class Commands(dict):
             if use_shlex:
                 return shlex.split(data)
             else:
-                return data.split()
+                return data.split(' ')
         return []
 
     @irc3.event((r'(@(?P<tags>\S+) )?:(?P<mask>\S+) PRIVMSG (?P<target>\S+) '

--- a/tests/test_irc3d.py
+++ b/tests/test_irc3d.py
@@ -66,6 +66,17 @@ class TestServer(testing.ServerTestCase):
         self.assertSent(
             s.client1, ':irc.com 401 client1 #irc5 :No such nick/channel')
 
+        # Test control codes integrity
+        for code in '\x02\x03\x1D\x1F\x16\x0F':
+            for pattern in ('X%sY', '%s'):
+                msg = pattern % (5 * code)
+                s.client1.reset()
+                s.client1.dispatch('PRIVMSG client1 :%s' % msg)
+                self.assertSent(
+                    s.client1,
+                    ':{mask} PRIVMSG client1 :%s' % msg,
+                    s.client1)
+
     def test_motd(self):
         s = self.callFTU(clients=1)
         s.config['testing'] = False


### PR DESCRIPTION
This fixes the parsing of irc3d PRIVMSG command

Some IRC control codes such as 0x1D (italic) are considered as
whitespace in unicode and they get converted to regular spaces.

Since RFC2812 states that only space (0x20) is considered whitespace,
only splitting by space seems reasonable.