### PR TITLE
Added method for sending /me

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -237,6 +237,10 @@ class IrcBot(base.IrcObject):
                                        nowait=nowait)
                 return f
 
+    def action(self, target, message, nowait=False):
+        return self.privmsg(target, '\x01ACTION %s\x01' % message,
+                            nowait=nowait)
+
     def notice(self, target, message, nowait=False):
         """send a notice to target"""
         if message:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -36,6 +36,8 @@ class TestBot(BotTestCase):
         self.assertSent(['PRIVMSG gawel :Youhou!'])
         bot.notice('gawel', 'Youhou!')
         self.assertSent(['NOTICE gawel :Youhou!'])
+        bot.action('gawel', 'does some cool action')
+        self.assertSent(['PRIVMSG gawel :\x01ACTION does some cool action\x01'])
 
     def test_long_message(self):
         bot = self.callFTU(max_length=8)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -36,8 +36,8 @@ class TestBot(BotTestCase):
         self.assertSent(['PRIVMSG gawel :Youhou!'])
         bot.notice('gawel', 'Youhou!')
         self.assertSent(['NOTICE gawel :Youhou!'])
-        bot.action('gawel', 'does some cool action')
-        self.assertSent(['PRIVMSG gawel :\x01ACTION does some cool action\x01'])
+        bot.action('gawel', 'does a cool action')
+        self.assertSent(['PRIVMSG gawel :\x01ACTION does a cool action\x01'])
 
     def test_long_message(self):
         bot = self.callFTU(max_length=8)


### PR DESCRIPTION
This PR adds a method ```action``` to the bot which sends a ```/me```.