### PR TITLE
Ability to silence "Invalid arguments." response.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-language: python
-python: 3.5
 sudo: false
+language: python
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 services:
   - redis-server
 install:
-  - pip install tox coveralls
+  - pip install tox-travis coveralls
 script:
   - tox
 after_success:
   - coveralls
-env:
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=flake8
-  - TOXENV=docs

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -302,9 +302,7 @@ class Commands(dict):
             data = self.split_command(
                 data, use_shlex=predicates.get('use_shlex', True))
         except ValueError as e:
-            if predicates.get('quiet', False) is True:
-                return
-            else:
+            if not predicates.get('quiet', False):
                 self.context.privmsg(to, 'Invalid arguments: {}.'.format(e))
                 return
         docopt_args = dict(help=False)
@@ -314,9 +312,7 @@ class Commands(dict):
         try:
             args = docopt.docopt(doc, [cmd_name] + data, **docopt_args)
         except docopt.DocoptExit:
-            if predicates.get('quiet', False) is True:
-                return
-            else:
+            if not predicates.get('quiet', False):
                 self.context.privmsg(to, 'Invalid arguments.')
         else:
             uid = (cmd_name, to)

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -304,7 +304,7 @@ class Commands(dict):
         except ValueError as e:
             if not predicates.get('quiet', False):
                 self.context.privmsg(to, 'Invalid arguments: {}.'.format(e))
-                return
+            return
         docopt_args = dict(help=False)
         if "options_first" in predicates:
             docopt_args.update(options_first=predicates["options_first"])

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -302,8 +302,11 @@ class Commands(dict):
             data = self.split_command(
                 data, use_shlex=predicates.get('use_shlex', True))
         except ValueError as e:
-            self.context.privmsg(to, 'Invalid arguments: {}.'.format(e))
-            return
+            if predicates.get('quiet', False) is True:
+                return
+            else:
+                self.context.privmsg(to, 'Invalid arguments: {}.'.format(e))
+                return
         docopt_args = dict(help=False)
         if "options_first" in predicates:
             docopt_args.update(options_first=predicates["options_first"])
@@ -311,7 +314,10 @@ class Commands(dict):
         try:
             args = docopt.docopt(doc, [cmd_name] + data, **docopt_args)
         except docopt.DocoptExit:
-            self.context.privmsg(to, 'Invalid arguments.')
+            if predicates.get('quiet', False) is True:
+                return
+            else:
+                self.context.privmsg(to, 'Invalid arguments.')
         else:
             uid = (cmd_name, to)
             use_client = isinstance(client, asyncio.Protocol)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -15,7 +15,8 @@ import os
                  aliases=['cmd_alias'],
                  show_in_help_list=False,
                  use_shlex=False,
-                 options_first=True)
+                 options_first=True,
+                 quiet=True)
 @dcc.dcc_command(options_first=True)
 def cmd(bot, *args):
     """Test command
@@ -210,6 +211,12 @@ class TestCommands(BotTestCase):
         bot = self.callFTU(nick='nono')
         bot.dispatch(':bar!user@host PRIVMSG nono :!ping xx')
         self.assertSent(['PRIVMSG bar :Invalid arguments.'])
+
+    def test_invalid_arguments_hides(self):
+        bot = self.callFTU(nick='nono')
+        bot.include(__name__)
+        bot.dispatch(':bar!user@host PRIVMSG #chan :!cmd xx')
+        self.assertNothingSent()
 
     def test_command_case_insensitive(self):
         bot = self.callFTU(nick='nono')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,7 +33,7 @@ def cmd_view(bot, *args):
     return 'Done'
 
 
-@command.command
+@command.command(quiet=True)
 def cmd_arg(bot, *args):
     """test command
 
@@ -160,6 +160,18 @@ class TestCommands(BotTestCase):
         bot.dispatch(':bar!user@host PRIVMSG foo :!cmd_arg   "test test" ')
         self.assertSent(['PRIVMSG bar :Done'])
 
+    def test_command_argument_quiet(self):
+        bot = self.callFTU(nick='nono')
+        bot.include(__name__)
+        bot.dispatch(':bar!user@host PRIVMSG #chan :!cmd xx')
+        self.assertNothingSent()
+
+    def test_command_argument_quiet_shlex(self):
+        bot = self.callFTU(nick='nono')
+        bot.include(__name__)
+        bot.dispatch(':bar!user@host PRIVMSG #chan :!cmd_arg "test')
+        self.assertNothingSent()
+
     def test_private_command(self):
         bot = self.callFTU()
         bot.dispatch(':bar!user@host PRIVMSG nono :!ping')
@@ -212,11 +224,11 @@ class TestCommands(BotTestCase):
         bot.dispatch(':bar!user@host PRIVMSG nono :!ping xx')
         self.assertSent(['PRIVMSG bar :Invalid arguments.'])
 
-    def test_invalid_arguments_hides(self):
+    def test_invalid_arguments_shlex(self):
         bot = self.callFTU(nick='nono')
-        bot.include(__name__)
-        bot.dispatch(':bar!user@host PRIVMSG #chan :!cmd xx')
-        self.assertNothingSent()
+        bot.dispatch(':bar!user@host PRIVMSG nono :!ping "xx')
+        self.assertSent(
+            ['PRIVMSG bar :Invalid arguments: No closing quotation.'])
 
     def test_command_case_insensitive(self):
         bot = self.callFTU(nick='nono')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist = py33,py34,py35,flake8,docs
 
+[travis]
+python =
+    3.5: py35, flake8, docs
+
 [testenv]
 skipsdist=true
 skip_install=true


### PR DESCRIPTION
Added an option the `@command` decorator that prevent the bot from responding with "Invalid arguments." when a command is used incorrectly along with the test units to cover the new option.

example:
```python
@command(quiet=True)
def cmd(self, mask, target, args):
    # rest of command...
```