### PR TITLE
load modules using pkg_resources

### DIFF
--- a/irc3/base.py
+++ b/irc3/base.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 
 try:
     import pkg_resources
+    from pkg_resources import iter_entry_points
     HAS_PKG_RESOURCES = True
 except ImportError:  # pragma: no cover
     HAS_PKG_RESOURCES = False
@@ -205,10 +206,13 @@ class IrcObject:
                     module = utils.maybedotted(module)
                 except LookupError as exc:
                     if HAS_PKG_RESOURCES:
-                        for entry_point in pkg_resources.iter_entry_points('irc3.loader', module):
-                            module = entry_point.load()
-                            break
-                        else:
+                        entry_points = iter_entry_points(
+                            'irc3.loader',
+                            module
+                        )
+                        try:
+                            module = next(entry_points).load()
+                        except StopIteration:
                             raise exc
                     else:
                         raise exc

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ test_requires = [
     'twitter',
     'aiocron',
     'redis',
-    'pytest'
+    'pytest',
+    'irc3-plugins-test',
 ]
 
 install_requires_py33 = [

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -158,4 +158,4 @@ class TestBot(BotTestCase):
     def test_pkg_resources_entry_points_exception(self):
         config = dict(includes=['irc3.plugins.badtest'])
         with self.assertRaises(LookupError):
-            bot = self.callFTU(**config)
+            self.callFTU(**config)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from irc3.testing import BotTestCase
 from irc3.testing import patch
+from irc3_plugins_test import test
 import logging
 
 
@@ -147,3 +148,14 @@ class TestBot(BotTestCase):
     def test_SIGHUP(self):
         bot = self.callFTU()
         bot.SIGHUP()
+
+    def test_pkg_resources_entry_points(self):
+        config = dict(includes=['irc3.plugins.test'])
+        bot = self.callFTU(**config)
+        plugin = bot.get_plugin(test.test)
+        self.assertEqual(plugin, 'success')
+
+    def test_pkg_resources_entry_points_exception(self):
+        config = dict(includes=['irc3.plugins.badtest'])
+        with self.assertRaises(LookupError):
+            bot = self.callFTU(**config)


### PR DESCRIPTION
This will allow for people to provide their own plugins and just be able to specify them by using entry_points in pkg_resources.

This is an example, that I have added a test for.

https://github.com/gtmanfred/irc3-plugins-test

Basically, you add an entry point for `irc3.loader` and then the name of the plugin points to what module should be loaded.

```
setuptools.setup(
    name='irc3-plugins-test',
    summary='test plugin for irc3',
    version='0.0.3',
    long_description=desc,
    author='Daniel Wallace',
    author_email='daniel@gtmanfred.com',
    url='https://github.com/gtmanfred/irc3-plugins-test',
    packages=['irc3_plugins_test',],
    entry_points='''
        [irc3.loader]
        irc3.plugins.test = irc3_plugins_test.test
    ''',
)
```
