### PR TITLE
fix bug in slack plugin

### DIFF
--- a/irc3/plugins/slack.py
+++ b/irc3/plugins/slack.py
@@ -133,7 +133,7 @@ class Slack:
 
     def get_user_by_id(self, matchobj):
         return matchobj.group('readable') or '@{0}'.format(
-            self.slack_users[matchobj.group('userId')]['name']
+            self.slack_users[matchobj.group('userId')]
         )
 
     def get_emoji(self, matchobj):

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -34,7 +34,7 @@ class TestSlack(BotTestCase):
         bot = self.callFTU()
         plugin = bot.get_plugin(slack.Slack)
         plugin.slack_users = {
-            'U12345': {'name': 'daniel'},
+            'U12345': 'daniel',
         }
         self.assertEqual('@daniel', plugin.parse_text('<@U12345>'))
         self.assertEqual('user', plugin.parse_text('<@U12345|user>'))


### PR DESCRIPTION
I made a mistake at some point and simplified the storage down to just the name, since that is the only thing I needed about a user.