### PR TITLE
Update userlist.py

### DIFF
--- a/irc3/plugins/userlist.py
+++ b/irc3/plugins/userlist.py
@@ -69,7 +69,10 @@ class Channel(set):
             self.modes[mode].add(item)
 
     def remove(self, item):
-        set.remove(self, item)
+        try:
+            set.remove(self, item)
+        except KeyError:
+            pass
         for items in self.modes.values():
             if item in items:
                 items.remove(item)


### PR DESCRIPTION
Sometimes (e.g. when using Twitch's IRC chat interface) server doesn't send "JOIN" message before "PART" message. `set.remove` throws `KeyError` when trying to remove an item that is not in set.