### PR TITLE
Except a KeyError on missing twitter configuration

### DIFF
--- a/irc3/plugins/social.py
+++ b/irc3/plugins/social.py
@@ -121,15 +121,15 @@ class Social:
             auth = irc3.utils.maybedotted(config.pop('auth_factory'))
             factory = irc3.utils.maybedotted(config.pop('factory'))
             adapter = irc3.utils.maybedotted(config.pop('adapter'))
-        except LookupError as e:  # pragma: no cover
-            self.bot.log.exception(e)
-        else:
             if name in self.bot.config:
                 c = self.bot.config[name]
             else:
                 c = self.bot.config[self.default_network]
             config['auth'] = auth(c['token'], c['token_secret'],
                                   c['key'], c['secret'])
+        except (LookupError, KeyError) as e:  # pragma: no cover
+            self.bot.log.exception(e)
+        else:
             return adapter(self.bot, factory(**config))
 
     @irc3.extend


### PR DESCRIPTION
Had this bug while trying to run alain locally without twitter credentials (not found on the server neither but it's another issue).

Still willing to try alain locally I expected the exception to log it instead of crashing.