### PR TITLE
Correctly interpolate regexes in async queries (corrects #185)

### DIFF
--- a/irc3/asynchronous.py
+++ b/irc3/asynchronous.py
@@ -10,8 +10,14 @@ class event:
     iscoroutine = True
 
     def __init__(self, **kwargs):
+        # kwargs get interpolated into the regex.
+        # Any kwargs not ending in _re get escaped
         self.meta = kwargs.get('meta')
-        regexp = self.meta['match'].format(**{k: re.escape(v) for (k, v) in kwargs.items()})
+        regexp = self.meta['match'].format(**{
+            k: v if k.endswith('_re') else re.escape(v)
+            for (k, v) in kwargs.items()
+            if k != 'meta'
+        })
         self.regexp = regexp
         regexp = getattr(self.regexp, 're', self.regexp)
         self.cregexp = re.compile(regexp).match

--- a/irc3/plugins/asynchronious.py
+++ b/irc3/plugins/asynchronious.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
+import re
 from irc3.asynchronous import AsyncEvents
 from irc3 import utils
 from irc3 import dec
@@ -373,6 +374,7 @@ class Async:
         """
         nicknames = [n.lower() for n in nicknames]
         self.context.send_line('ISON :{0}'.format(' '.join(nicknames)))
+        nicknames = [re.escape(n) for n in nicknames]
         return self.async_ison(nicknames_re='(%s)' % '|'.join(nicknames),
                                **kwargs)
 

--- a/irc3/plugins/asynchronious.py
+++ b/irc3/plugins/asynchronious.py
@@ -186,7 +186,7 @@ class WhoNick(AsyncEvents):
 class IsOn(AsyncEvents):
 
     events = (
-        {"match": "(?i)^:\S+ 303 \S+ :(?P<nicknames>({nicknames}.*|$))",
+        {"match": "(?i)^:\S+ 303 \S+ :(?P<nicknames>({nicknames_re}.*|$))",
          "final": True},
     )
 
@@ -373,7 +373,7 @@ class Async:
         """
         nicknames = [n.lower() for n in nicknames]
         self.context.send_line('ISON :{0}'.format(' '.join(nicknames)))
-        return self.async_ison(nicknames='(%s)' % '|'.join(nicknames),
+        return self.async_ison(nicknames_re='(%s)' % '|'.join(nicknames),
                                **kwargs)
 
     @dec.extend

--- a/irc3/plugins/sasl.py
+++ b/irc3/plugins/sasl.py
@@ -54,7 +54,7 @@ class Sasl:
         auth = ('{sasl_username}\0'
                 '{sasl_username}\0'
                 '{sasl_password}').format(**self.bot.config)
-        auth = base64.encodestring(auth.encode('utf8'))
+        auth = base64.encodebytes(auth.encode('utf8'))
         auth = auth.decode('utf8').rstrip('\n')
         self.bot.send_line('AUTHENTICATE ' + auth)
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -18,14 +18,14 @@ async def test_whois_fail(irc3_bot_factory):
 async def test_whois_success(irc3_bot_factory):
     bot = irc3_bot_factory(includes=['irc3.plugins.asynchronious'])
     assert len(bot.registry.events_re['in']) == 0
-    task = bot.async_cmds.whois(nick='GaWel')
+    task = bot.async_cmds.whois(nick='Ga[W]el', timeout=0.1)
     assert len(bot.registry.events_re['in']) > 2
-    bot.dispatch(':localhost 311 me gawel username localhost * :realname')
-    bot.dispatch(':localhost 319 me gawel :@#irc3')
-    bot.dispatch(':localhost 312 me gawel localhost :Paris, FR')
-    bot.dispatch(':localhost 671 me gawel :is using a secure connection')
-    bot.dispatch(':localhost 330 me gawel gawel :is logged in as')
-    bot.dispatch(':localhost 318 me gawel :End')
+    bot.dispatch(':localhost 311 me ga[w]el username localhost * :realname')
+    bot.dispatch(':localhost 319 me ga[w]el :@#irc3')
+    bot.dispatch(':localhost 312 me ga[w]el localhost :Paris, FR')
+    bot.dispatch(':localhost 671 me ga[w]el :is using a secure connection')
+    bot.dispatch(':localhost 330 me ga[w]el gawel :is logged in as')
+    bot.dispatch(':localhost 318 me ga[w]el :End')
     result = await task
     assert len(bot.registry.events_re['in']) == 0
     assert result['success']


### PR DESCRIPTION
- Fix use of deprecated function removed in Py39
- Correctly interpolate regexes in async queries (corrects #185)
