### PR TITLE
Allow comma-separated chans in server userlist JOIN

### DIFF
--- a/irc3d/plugins/userlist.py
+++ b/irc3d/plugins/userlist.py
@@ -71,15 +71,18 @@ class ServerUserlist(userlist.Userlist):
 
             %%JOIN <channel>
         """
-        if args['<channel>'] in client.channels:
-            return
-        message = ':{mask} JOIN {<channel>}'
-        kwargs.update(
-            broadcast=message.format(mask=client.mask, **args),
-            channel=args['<channel>'])
-        self.join(client.nick, client.mask, client=client, **kwargs)
-        client.channels.add(args['<channel>'])
-        self.NAMES(client=client, **kwargs)
+        for channel in args['<channel>'].split(','):
+            if channel in client.channels:
+                continue
+            message = ':{mask} JOIN {<channel>}'
+            kwargs.update(
+                broadcast=message.format(
+                    mask=client.mask, **dict(args, **{'<channel>': channel})
+                ),
+                channel=channel)
+            self.join(client.nick, client.mask, client=client, **kwargs)
+            client.channels.add(channel)
+            self.NAMES(client=client, **kwargs)
 
     @irc3d.command
     def PART(self, client, args=None, **kwargs):

--- a/tests/test_irc3d_userlist.py
+++ b/tests/test_irc3d_userlist.py
@@ -87,7 +87,7 @@ class TestServerUserList(testing.ServerTestCase):
         self.assertSent(s.client2, ':client1!uclient1@127.0.0.1 NICK irc3')
         self.assertNotSent(s.client3, ':client1!uclient1@127.0.0.1 NICK irc3')
 
-        s.client3.dispatch('JOIN #irc')
+        s.client3.dispatch('JOIN #irc,#irc3')
         s.client1.dispatch('NICK client1')
         self.assertSent(s.client1, ':irc3!uclient1@127.0.0.1 NICK client1')
         self.assertSent(s.client2, ':irc3!uclient1@127.0.0.1 NICK client1')
@@ -116,6 +116,7 @@ class TestServerUserList(testing.ServerTestCase):
         self.assertSent(s.client1, ':irc.com 319 client1 :#irc3')
 
         s.client3.dispatch('PART #irc :Bye')
+        s.client3.dispatch('PART #irc3 :Bye')
         self.assertSent(s.client3, ':{mask} PART #irc :Bye', s.client3)
         self.assertSent(s.client1, ':{mask} PART #irc :Bye', s.client3)
         self.assertNotSent(s.client2, ':{mask} PART #irc :Bye', s.client3)


### PR DESCRIPTION
Hi,

I guess some clients want to send multi-channel JOINs as `foo,bar,baz`, which I couldn't get the test server to accept. Sorry if I'm wrong and this PR is just nonsense.

Thanks!

P.S. I sent you an email about this last summer (apologies if that was annoying; I wasn't allowed to use GitHub back then).