### PR TITLE
feeds: All date formats can't be compared as strings.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ try:
     StrictRedis().flushdb()
 except (ImportError, ConnectionError):
     import re
-    req_redis = re.compile(".*#[^#]*\s*require?\s*redis\s*$", re.IGNORECASE)
+    req_redis = re.compile(r".*#[^#]*\s*require?\s*redis\s*$", re.IGNORECASE)
 
     def pytest_runtest_setup(item):
         if getattr(item, 'dtest', None):

--- a/irc3/_parse_rfc.py
+++ b/irc3/_parse_rfc.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 import pprint
 import re
 
-_re_num = re.compile('\s(?P<num>\d+)\s+(?P<name>(RPL|ERR)_\w+)\s*(?P<_>.*)')
-_re_mask = re.compile('^\s{24,25}(?P<_>("(<|:).*|\S.*"$))')
+_re_num = re.compile(r'\s(?P<num>\d+)\s+(?P<name>(RPL|ERR)_\w+)\s*(?P<_>.*)')
+_re_mask = re.compile(r'^\s{24,25}(?P<_>("(<|:).*|\S.*"$))')
 
 
 def main():
@@ -121,7 +121,7 @@ class retcode(int):
                 v = m.groupdict()['m'].strip('<>')
                 v = repl(v)
                 params.append(v)
-                return '(?P<%s>\S+)' % v
+                return r'(?P<%s>\S+)' % v
 
             mask = _re_sub.sub(msub, omask)
             if '???? ' in mask:
@@ -131,18 +131,18 @@ class retcode(int):
             if ':' in mask:
                 mask = mask.split(':', 1)[0]
                 mask += ':(?P<data>.*)'
-            mask = '(?P<srv>\S+) ' + str(i) + ' (?P<me>\S+) "\n    "' + mask
+            mask = r'(?P<srv>\S+) ' + str(i) + ' (?P<me>\\S+) "\n    r"' + mask
             mask = mask.replace(
-                ' (?P<server>\S+)',
-                ' "\n    "(?P<server>\S+)')
+                r' (?P<server>\S+)',
+                ' "\n    r"(?P<server>\\S+)')
             mask = mask.replace(
-                ' (?P<sent_messages>\S+)',
-                ' "\n    "(?P<sent_messages>\S+)')
+                r' (?P<sent_messages>\S+)',
+                ' "\n    r"(?P<sent_messages>\\S+)')
             item['mask'] = mask
             params = [p for p in params if '<%s>' % p in mask]
             if '<data>' in mask and 'data' not in params:
                 params.append('data')
-            out.write('%(name)s.re = (\n    "^:%(mask)s")\n' % item)
+            out.write('%(name)s.re = (\n    r"^:%(mask)s")\n' % item)
             params = pprint.pformat(
                 ['srv', 'me'] + params, width=60, indent=4)
             if len(params) > 60:
@@ -157,6 +157,7 @@ class retcode(int):
         if i in valids:
             out.write('    %(num)s: %(name)s,\n' % item)
     out.write('}\n')
+    out.close()
 
 
 if __name__ == '__main__':

--- a/irc3/_rfc.py
+++ b/irc3/_rfc.py
@@ -6,8 +6,8 @@ class retcode(int):
 RPL_TRACELINK = retcode(200)
 RPL_TRACELINK.name = "RPL_TRACELINK"
 RPL_TRACELINK.re = (
-    "^:(?P<srv>\S+) 200 (?P<me>\S+) "
-    "(?P<next_server>\S+)")
+    r"^:(?P<srv>\S+) 200 (?P<me>\S+) "
+    r"(?P<next_server>\S+)")
 RPL_TRACELINK.tpl = (
     ':{c.srv} 200 {c.nick} '
     '{next_server}')
@@ -16,9 +16,9 @@ RPL_TRACELINK.params = ['srv', 'me', 'next_server']
 RPL_TRACECONNECTING = retcode(201)
 RPL_TRACECONNECTING.name = "RPL_TRACECONNECTING"
 RPL_TRACECONNECTING.re = (
-    "^:(?P<srv>\S+) 201 (?P<me>\S+) "
-    "Try. (?P<class>\S+) "
-    "(?P<server>\S+)")
+    r"^:(?P<srv>\S+) 201 (?P<me>\S+) "
+    r"Try. (?P<class>\S+) "
+    r"(?P<server>\S+)")
 RPL_TRACECONNECTING.tpl = (
     ':{c.srv} 201 {c.nick} '
     'Try. {class} {server}')
@@ -27,9 +27,9 @@ RPL_TRACECONNECTING.params = ['srv', 'me', 'class', 'server']
 RPL_TRACEHANDSHAKE = retcode(202)
 RPL_TRACEHANDSHAKE.name = "RPL_TRACEHANDSHAKE"
 RPL_TRACEHANDSHAKE.re = (
-    "^:(?P<srv>\S+) 202 (?P<me>\S+) "
-    "H.S. (?P<class>\S+) "
-    "(?P<server>\S+)")
+    r"^:(?P<srv>\S+) 202 (?P<me>\S+) "
+    r"H.S. (?P<class>\S+) "
+    r"(?P<server>\S+)")
 RPL_TRACEHANDSHAKE.tpl = (
     ':{c.srv} 202 {c.nick} '
     'H.S. {class} {server}')
@@ -38,8 +38,8 @@ RPL_TRACEHANDSHAKE.params = ['srv', 'me', 'class', 'server']
 RPL_TRACEUNKNOWN = retcode(203)
 RPL_TRACEUNKNOWN.name = "RPL_TRACEUNKNOWN"
 RPL_TRACEUNKNOWN.re = (
-    "^:(?P<srv>\S+) 203 (?P<me>\S+) "
-    "\S+ (?P<class>\S+) [(?P<clientip>\S+)]")
+    r"^:(?P<srv>\S+) 203 (?P<me>\S+) "
+    r"\S+ (?P<class>\S+) [(?P<clientip>\S+)]")
 RPL_TRACEUNKNOWN.tpl = (
     ':{c.srv} 203 {c.nick} '
     '???? {class} [{clientip}]')
@@ -48,8 +48,8 @@ RPL_TRACEUNKNOWN.params = ['srv', 'me', 'class', 'clientip']
 RPL_TRACEOPERATOR = retcode(204)
 RPL_TRACEOPERATOR.name = "RPL_TRACEOPERATOR"
 RPL_TRACEOPERATOR.re = (
-    "^:(?P<srv>\S+) 204 (?P<me>\S+) "
-    "Oper (?P<class>\S+) (?P<nick>\S+)")
+    r"^:(?P<srv>\S+) 204 (?P<me>\S+) "
+    r"Oper (?P<class>\S+) (?P<nick>\S+)")
 RPL_TRACEOPERATOR.tpl = (
     ':{c.srv} 204 {c.nick} '
     'Oper {class} {nick}')
@@ -58,8 +58,8 @@ RPL_TRACEOPERATOR.params = ['srv', 'me', 'class', 'nick']
 RPL_TRACEUSER = retcode(205)
 RPL_TRACEUSER.name = "RPL_TRACEUSER"
 RPL_TRACEUSER.re = (
-    "^:(?P<srv>\S+) 205 (?P<me>\S+) "
-    "User (?P<class>\S+) (?P<nick>\S+)")
+    r"^:(?P<srv>\S+) 205 (?P<me>\S+) "
+    r"User (?P<class>\S+) (?P<nick>\S+)")
 RPL_TRACEUSER.tpl = (
     ':{c.srv} 205 {c.nick} '
     'User {class} {nick}')
@@ -68,8 +68,8 @@ RPL_TRACEUSER.params = ['srv', 'me', 'class', 'nick']
 RPL_TRACESERVER = retcode(206)
 RPL_TRACESERVER.name = "RPL_TRACESERVER"
 RPL_TRACESERVER.re = (
-    "^:(?P<srv>\S+) 206 (?P<me>\S+) "
-    "(?P<mask>\S+)")
+    r"^:(?P<srv>\S+) 206 (?P<me>\S+) "
+    r"(?P<mask>\S+)")
 RPL_TRACESERVER.tpl = (
     ':{c.srv} 206 {c.nick} '
     '{mask}')
@@ -78,8 +78,8 @@ RPL_TRACESERVER.params = ['srv', 'me', 'mask']
 RPL_TRACENEWTYPE = retcode(208)
 RPL_TRACENEWTYPE.name = "RPL_TRACENEWTYPE"
 RPL_TRACENEWTYPE.re = (
-    "^:(?P<srv>\S+) 208 (?P<me>\S+) "
-    "(?P<newtype>\S+) 0 (?P<client>\S+)")
+    r"^:(?P<srv>\S+) 208 (?P<me>\S+) "
+    r"(?P<newtype>\S+) 0 (?P<client>\S+)")
 RPL_TRACENEWTYPE.tpl = (
     ':{c.srv} 208 {c.nick} '
     '{newtype} 0 {client}')
@@ -88,9 +88,9 @@ RPL_TRACENEWTYPE.params = ['srv', 'me', 'newtype', 'client']
 RPL_STATSLINKINFO = retcode(211)
 RPL_STATSLINKINFO.name = "RPL_STATSLINKINFO"
 RPL_STATSLINKINFO.re = (
-    "^:(?P<srv>\S+) 211 (?P<me>\S+) "
-    "(?P<linkname>\S+) (?P<sendq>\S+) "
-    "(?P<sent_messages>\S+) (?P<received_bytes>\S+) (?P<time_open>\S+)")
+    r"^:(?P<srv>\S+) 211 (?P<me>\S+) "
+    r"(?P<linkname>\S+) (?P<sendq>\S+) "
+    r"(?P<sent_messages>\S+) (?P<received_bytes>\S+) (?P<time_open>\S+)")
 RPL_STATSLINKINFO.tpl = (
     ':{c.srv} 211 {c.nick} '
     ':{linkname} {sendq} {sent_messages} {received_bytes} {time_open}')
@@ -106,8 +106,8 @@ RPL_STATSLINKINFO.params = [
 RPL_STATSCOMMANDS = retcode(212)
 RPL_STATSCOMMANDS.name = "RPL_STATSCOMMANDS"
 RPL_STATSCOMMANDS.re = (
-    "^:(?P<srv>\S+) 212 (?P<me>\S+) "
-    "(?P<cmd>\S+) (?P<count>\S+)")
+    r"^:(?P<srv>\S+) 212 (?P<me>\S+) "
+    r"(?P<cmd>\S+) (?P<count>\S+)")
 RPL_STATSCOMMANDS.tpl = (
     ':{c.srv} 212 {c.nick} '
     '{cmd} {count}')
@@ -116,8 +116,8 @@ RPL_STATSCOMMANDS.params = ['srv', 'me', 'cmd', 'count']
 RPL_STATSCLINE = retcode(213)
 RPL_STATSCLINE.name = "RPL_STATSCLINE"
 RPL_STATSCLINE.re = (
-    "^:(?P<srv>\S+) 213 (?P<me>\S+) "
-    "C (?P<host>\S+) . (?P<nick>\S+) (?P<port>\S+) (?P<class>\S+)")
+    r"^:(?P<srv>\S+) 213 (?P<me>\S+) "
+    r"C (?P<host>\S+) . (?P<nick>\S+) (?P<port>\S+) (?P<class>\S+)")
 RPL_STATSCLINE.tpl = (
     ':{c.srv} 213 {c.nick} '
     'C {host} * {nick} {port} {class}')
@@ -126,8 +126,8 @@ RPL_STATSCLINE.params = ['srv', 'me', 'host', 'nick', 'port', 'class']
 RPL_STATSNLINE = retcode(214)
 RPL_STATSNLINE.name = "RPL_STATSNLINE"
 RPL_STATSNLINE.re = (
-    "^:(?P<srv>\S+) 214 (?P<me>\S+) "
-    "N (?P<host>\S+) . (?P<nick>\S+) (?P<port>\S+) (?P<class>\S+)")
+    r"^:(?P<srv>\S+) 214 (?P<me>\S+) "
+    r"N (?P<host>\S+) . (?P<nick>\S+) (?P<port>\S+) (?P<class>\S+)")
 RPL_STATSNLINE.tpl = (
     ':{c.srv} 214 {c.nick} '
     'N {host} * {nick} {port} {class}')
@@ -136,8 +136,8 @@ RPL_STATSNLINE.params = ['srv', 'me', 'host', 'nick', 'port', 'class']
 RPL_STATSILINE = retcode(215)
 RPL_STATSILINE.name = "RPL_STATSILINE"
 RPL_STATSILINE.re = (
-    "^:(?P<srv>\S+) 215 (?P<me>\S+) "
-    "I (?P<host>\S+) . (?P<host1>\S+) (?P<port>\S+) (?P<class>\S+)")
+    r"^:(?P<srv>\S+) 215 (?P<me>\S+) "
+    r"I (?P<host>\S+) . (?P<host1>\S+) (?P<port>\S+) (?P<class>\S+)")
 RPL_STATSILINE.tpl = (
     ':{c.srv} 215 {c.nick} '
     'I {host} * {host1} {port} {class}')
@@ -146,8 +146,8 @@ RPL_STATSILINE.params = ['srv', 'me', 'host', 'host1', 'port', 'class']
 RPL_STATSKLINE = retcode(216)
 RPL_STATSKLINE.name = "RPL_STATSKLINE"
 RPL_STATSKLINE.re = (
-    "^:(?P<srv>\S+) 216 (?P<me>\S+) "
-    "K (?P<host>\S+) . (?P<username>\S+) (?P<port>\S+) (?P<class>\S+)")
+    r"^:(?P<srv>\S+) 216 (?P<me>\S+) "
+    r"K (?P<host>\S+) . (?P<username>\S+) (?P<port>\S+) (?P<class>\S+)")
 RPL_STATSKLINE.tpl = (
     ':{c.srv} 216 {c.nick} '
     'K {host} * {username} {port} {class}')
@@ -156,8 +156,8 @@ RPL_STATSKLINE.params = ['srv', 'me', 'host', 'username', 'port', 'class']
 RPL_STATSYLINE = retcode(218)
 RPL_STATSYLINE.name = "RPL_STATSYLINE"
 RPL_STATSYLINE.re = (
-    "^:(?P<srv>\S+) 218 (?P<me>\S+) "
-    "frequency> (?P<max_sendq>\S+)")
+    r"^:(?P<srv>\S+) 218 (?P<me>\S+) "
+    r"frequency> (?P<max_sendq>\S+)")
 RPL_STATSYLINE.tpl = (
     ':{c.srv} 218 {c.nick} '
     'frequency> {max_sendq}')
@@ -166,8 +166,8 @@ RPL_STATSYLINE.params = ['srv', 'me', 'max_sendq']
 RPL_ENDOFSTATS = retcode(219)
 RPL_ENDOFSTATS.name = "RPL_ENDOFSTATS"
 RPL_ENDOFSTATS.re = (
-    "^:(?P<srv>\S+) 219 (?P<me>\S+) "
-    "(?P<stats_letter>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 219 (?P<me>\S+) "
+    r"(?P<stats_letter>\S+) :(?P<data>.*)")
 RPL_ENDOFSTATS.tpl = (
     ':{c.srv} 219 {c.nick} '
     '{stats_letter} :End of /STATS report')
@@ -176,8 +176,8 @@ RPL_ENDOFSTATS.params = ['srv', 'me', 'stats_letter', 'data']
 RPL_UMODEIS = retcode(221)
 RPL_UMODEIS.name = "RPL_UMODEIS"
 RPL_UMODEIS.re = (
-    "^:(?P<srv>\S+) 221 (?P<me>\S+) "
-    "(?P<user_mode_string>\S+)")
+    r"^:(?P<srv>\S+) 221 (?P<me>\S+) "
+    r"(?P<user_mode_string>\S+)")
 RPL_UMODEIS.tpl = (
     ':{c.srv} 221 {c.nick} '
     '{user_mode_string}')
@@ -186,8 +186,8 @@ RPL_UMODEIS.params = ['srv', 'me', 'user_mode_string']
 RPL_STATSLLINE = retcode(241)
 RPL_STATSLLINE.name = "RPL_STATSLLINE"
 RPL_STATSLLINE.re = (
-    "^:(?P<srv>\S+) 241 (?P<me>\S+) "
-    "L (?P<hostmask>\S+) . (?P<servername>\S+) (?P<maxdepth>\S+)")
+    r"^:(?P<srv>\S+) 241 (?P<me>\S+) "
+    r"L (?P<hostmask>\S+) . (?P<servername>\S+) (?P<maxdepth>\S+)")
 RPL_STATSLLINE.tpl = (
     ':{c.srv} 241 {c.nick} '
     'L {hostmask} * {servername} {maxdepth}')
@@ -196,8 +196,8 @@ RPL_STATSLLINE.params = ['srv', 'me', 'hostmask', 'servername', 'maxdepth']
 RPL_STATSUPTIME = retcode(242)
 RPL_STATSUPTIME.name = "RPL_STATSUPTIME"
 RPL_STATSUPTIME.re = (
-    "^:(?P<srv>\S+) 242 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 242 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_STATSUPTIME.tpl = (
     ':{c.srv} 242 {c.nick} '
     ':Server Up{days}days {hours}')
@@ -206,8 +206,8 @@ RPL_STATSUPTIME.params = ['srv', 'me', 'data']
 RPL_STATSOLINE = retcode(243)
 RPL_STATSOLINE.name = "RPL_STATSOLINE"
 RPL_STATSOLINE.re = (
-    "^:(?P<srv>\S+) 243 (?P<me>\S+) "
-    "O (?P<hostmask>\S+) . (?P<nick>\S+)")
+    r"^:(?P<srv>\S+) 243 (?P<me>\S+) "
+    r"O (?P<hostmask>\S+) . (?P<nick>\S+)")
 RPL_STATSOLINE.tpl = (
     ':{c.srv} 243 {c.nick} '
     'O {hostmask} * {nick}')
@@ -216,8 +216,8 @@ RPL_STATSOLINE.params = ['srv', 'me', 'hostmask', 'nick']
 RPL_STATSHLINE = retcode(244)
 RPL_STATSHLINE.name = "RPL_STATSHLINE"
 RPL_STATSHLINE.re = (
-    "^:(?P<srv>\S+) 244 (?P<me>\S+) "
-    "H (?P<hostmask>\S+) . (?P<servername>\S+)")
+    r"^:(?P<srv>\S+) 244 (?P<me>\S+) "
+    r"H (?P<hostmask>\S+) . (?P<servername>\S+)")
 RPL_STATSHLINE.tpl = (
     ':{c.srv} 244 {c.nick} '
     'H {hostmask} * {servername}')
@@ -226,8 +226,8 @@ RPL_STATSHLINE.params = ['srv', 'me', 'hostmask', 'servername']
 RPL_LUSERCLIENT = retcode(251)
 RPL_LUSERCLIENT.name = "RPL_LUSERCLIENT"
 RPL_LUSERCLIENT.re = (
-    "^:(?P<srv>\S+) 251 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 251 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_LUSERCLIENT.tpl = (
     ':{c.srv} 251 {c.nick} '
     ':There are {x} users and {y} invisible on {z} servers')
@@ -236,8 +236,8 @@ RPL_LUSERCLIENT.params = ['srv', 'me', 'data']
 RPL_LUSEROP = retcode(252)
 RPL_LUSEROP.name = "RPL_LUSEROP"
 RPL_LUSEROP.re = (
-    "^:(?P<srv>\S+) 252 (?P<me>\S+) "
-    "(?P<x>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 252 (?P<me>\S+) "
+    r"(?P<x>\S+) :(?P<data>.*)")
 RPL_LUSEROP.tpl = (
     ':{c.srv} 252 {c.nick} '
     '{x} :operator(s) online')
@@ -246,8 +246,8 @@ RPL_LUSEROP.params = ['srv', 'me', 'x', 'data']
 RPL_LUSERUNKNOWN = retcode(253)
 RPL_LUSERUNKNOWN.name = "RPL_LUSERUNKNOWN"
 RPL_LUSERUNKNOWN.re = (
-    "^:(?P<srv>\S+) 253 (?P<me>\S+) "
-    "(?P<x>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 253 (?P<me>\S+) "
+    r"(?P<x>\S+) :(?P<data>.*)")
 RPL_LUSERUNKNOWN.tpl = (
     ':{c.srv} 253 {c.nick} '
     '{x} :unknown connection(s)')
@@ -256,8 +256,8 @@ RPL_LUSERUNKNOWN.params = ['srv', 'me', 'x', 'data']
 RPL_LUSERCHANNELS = retcode(254)
 RPL_LUSERCHANNELS.name = "RPL_LUSERCHANNELS"
 RPL_LUSERCHANNELS.re = (
-    "^:(?P<srv>\S+) 254 (?P<me>\S+) "
-    "(?P<x>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 254 (?P<me>\S+) "
+    r"(?P<x>\S+) :(?P<data>.*)")
 RPL_LUSERCHANNELS.tpl = (
     ':{c.srv} 254 {c.nick} '
     '{x} :channels formed')
@@ -266,8 +266,8 @@ RPL_LUSERCHANNELS.params = ['srv', 'me', 'x', 'data']
 RPL_LUSERME = retcode(255)
 RPL_LUSERME.name = "RPL_LUSERME"
 RPL_LUSERME.re = (
-    "^:(?P<srv>\S+) 255 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 255 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_LUSERME.tpl = (
     ':{c.srv} 255 {c.nick} '
     ':I have {x} clients and {y}')
@@ -276,8 +276,8 @@ RPL_LUSERME.params = ['srv', 'me', 'data']
 RPL_ADMINME = retcode(256)
 RPL_ADMINME.name = "RPL_ADMINME"
 RPL_ADMINME.re = (
-    "^:(?P<srv>\S+) 256 (?P<me>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 256 (?P<me>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 RPL_ADMINME.tpl = (
     ':{c.srv} 256 {c.nick} '
     '{server} :Administrative info')
@@ -286,8 +286,8 @@ RPL_ADMINME.params = ['srv', 'me', 'server', 'data']
 RPL_ADMINLOC1 = retcode(257)
 RPL_ADMINLOC1.name = "RPL_ADMINLOC1"
 RPL_ADMINLOC1.re = (
-    "^:(?P<srv>\S+) 257 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 257 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ADMINLOC1.tpl = (
     ':{c.srv} 257 {c.nick} '
     ':{admin_info}')
@@ -296,8 +296,8 @@ RPL_ADMINLOC1.params = ['srv', 'me', 'data']
 RPL_ADMINLOC2 = retcode(258)
 RPL_ADMINLOC2.name = "RPL_ADMINLOC2"
 RPL_ADMINLOC2.re = (
-    "^:(?P<srv>\S+) 258 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 258 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ADMINLOC2.tpl = (
     ':{c.srv} 258 {c.nick} '
     ':{admin_info}')
@@ -306,8 +306,8 @@ RPL_ADMINLOC2.params = ['srv', 'me', 'data']
 RPL_ADMINEMAIL = retcode(259)
 RPL_ADMINEMAIL.name = "RPL_ADMINEMAIL"
 RPL_ADMINEMAIL.re = (
-    "^:(?P<srv>\S+) 259 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 259 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ADMINEMAIL.tpl = (
     ':{c.srv} 259 {c.nick} '
     ':{admin_info}')
@@ -316,8 +316,8 @@ RPL_ADMINEMAIL.params = ['srv', 'me', 'data']
 RPL_TRACELOG = retcode(261)
 RPL_TRACELOG.name = "RPL_TRACELOG"
 RPL_TRACELOG.re = (
-    "^:(?P<srv>\S+) 261 (?P<me>\S+) "
-    "File (?P<logfile>\S+) (?P<debug_level>\S+)")
+    r"^:(?P<srv>\S+) 261 (?P<me>\S+) "
+    r"File (?P<logfile>\S+) (?P<debug_level>\S+)")
 RPL_TRACELOG.tpl = (
     ':{c.srv} 261 {c.nick} '
     'File {logfile} {debug_level}')
@@ -326,8 +326,8 @@ RPL_TRACELOG.params = ['srv', 'me', 'logfile', 'debug_level']
 RPL_AWAY = retcode(301)
 RPL_AWAY.name = "RPL_AWAY"
 RPL_AWAY.re = (
-    "^:(?P<srv>\S+) 301 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 301 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_AWAY.tpl = (
     ':{c.srv} 301 {c.nick} '
     '{nick} :{away_message}')
@@ -336,8 +336,8 @@ RPL_AWAY.params = ['srv', 'me', 'nick', 'data']
 RPL_USERHOST = retcode(302)
 RPL_USERHOST.name = "RPL_USERHOST"
 RPL_USERHOST.re = (
-    "^:(?P<srv>\S+) 302 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 302 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_USERHOST.tpl = (
     ':{c.srv} 302 {c.nick} '
     ':[{reply}{{space}{reply}}]')
@@ -346,8 +346,8 @@ RPL_USERHOST.params = ['srv', 'me', 'data']
 RPL_ISON = retcode(303)
 RPL_ISON.name = "RPL_ISON"
 RPL_ISON.re = (
-    "^:(?P<srv>\S+) 303 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 303 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ISON.tpl = (
     ':{c.srv} 303 {c.nick} '
     ':{nicknames}')
@@ -356,8 +356,8 @@ RPL_ISON.params = ['srv', 'me', 'data']
 RPL_UNAWAY = retcode(305)
 RPL_UNAWAY.name = "RPL_UNAWAY"
 RPL_UNAWAY.re = (
-    "^:(?P<srv>\S+) 305 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 305 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_UNAWAY.tpl = (
     ':{c.srv} 305 {c.nick} '
     ':You are no longer marked as being away')
@@ -366,8 +366,8 @@ RPL_UNAWAY.params = ['srv', 'me', 'data']
 RPL_NOWAWAY = retcode(306)
 RPL_NOWAWAY.name = "RPL_NOWAWAY"
 RPL_NOWAWAY.re = (
-    "^:(?P<srv>\S+) 306 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 306 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_NOWAWAY.tpl = (
     ':{c.srv} 306 {c.nick} '
     ':You have been marked as being away')
@@ -376,8 +376,8 @@ RPL_NOWAWAY.params = ['srv', 'me', 'data']
 RPL_WHOISUSER = retcode(311)
 RPL_WHOISUSER.name = "RPL_WHOISUSER"
 RPL_WHOISUSER.re = (
-    "^:(?P<srv>\S+) 311 (?P<me>\S+) "
-    "(?P<nick>\S+) (?P<username>\S+) (?P<host>\S+) (?P<m>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 311 (?P<me>\S+) "
+    r"(?P<nick>\S+) (?P<username>\S+) (?P<host>\S+) (?P<m>\S+) :(?P<data>.*)")
 RPL_WHOISUSER.tpl = (
     ':{c.srv} 311 {c.nick} '
     '{nick} {username} {host} {m} :{realname}')
@@ -386,9 +386,9 @@ RPL_WHOISUSER.params = ['srv', 'me', 'nick', 'username', 'host', 'm', 'data']
 RPL_WHOISSERVER = retcode(312)
 RPL_WHOISSERVER.name = "RPL_WHOISSERVER"
 RPL_WHOISSERVER.re = (
-    "^:(?P<srv>\S+) 312 (?P<me>\S+) "
-    "(?P<nick>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 312 (?P<me>\S+) "
+    r"(?P<nick>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 RPL_WHOISSERVER.tpl = (
     ':{c.srv} 312 {c.nick} '
     '{nick} {server} :{server_info}')
@@ -397,8 +397,8 @@ RPL_WHOISSERVER.params = ['srv', 'me', 'nick', 'server', 'data']
 RPL_WHOISOPERATOR = retcode(313)
 RPL_WHOISOPERATOR.name = "RPL_WHOISOPERATOR"
 RPL_WHOISOPERATOR.re = (
-    "^:(?P<srv>\S+) 313 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 313 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_WHOISOPERATOR.tpl = (
     ':{c.srv} 313 {c.nick} '
     '{nick} :is an IRC operator')
@@ -407,8 +407,8 @@ RPL_WHOISOPERATOR.params = ['srv', 'me', 'nick', 'data']
 RPL_WHOWASUSER = retcode(314)
 RPL_WHOWASUSER.name = "RPL_WHOWASUSER"
 RPL_WHOWASUSER.re = (
-    "^:(?P<srv>\S+) 314 (?P<me>\S+) "
-    "(?P<nick>\S+) (?P<username>\S+) (?P<host>\S+) . :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 314 (?P<me>\S+) "
+    r"(?P<nick>\S+) (?P<username>\S+) (?P<host>\S+) . :(?P<data>.*)")
 RPL_WHOWASUSER.tpl = (
     ':{c.srv} 314 {c.nick} '
     '{nick} {username} {host} * :{realname}')
@@ -417,8 +417,8 @@ RPL_WHOWASUSER.params = ['srv', 'me', 'nick', 'username', 'host', 'data']
 RPL_ENDOFWHO = retcode(315)
 RPL_ENDOFWHO.name = "RPL_ENDOFWHO"
 RPL_ENDOFWHO.re = (
-    "^:(?P<srv>\S+) 315 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 315 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_ENDOFWHO.tpl = (
     ':{c.srv} 315 {c.nick} '
     '{nick} :End of /WHO list')
@@ -427,8 +427,8 @@ RPL_ENDOFWHO.params = ['srv', 'me', 'nick', 'data']
 RPL_WHOISIDLE = retcode(317)
 RPL_WHOISIDLE.name = "RPL_WHOISIDLE"
 RPL_WHOISIDLE.re = (
-    "^:(?P<srv>\S+) 317 (?P<me>\S+) "
-    "(?P<nick>\S+) (?P<x>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 317 (?P<me>\S+) "
+    r"(?P<nick>\S+) (?P<x>\S+) :(?P<data>.*)")
 RPL_WHOISIDLE.tpl = (
     ':{c.srv} 317 {c.nick} '
     '{nick} {x} :seconds idle')
@@ -437,8 +437,8 @@ RPL_WHOISIDLE.params = ['srv', 'me', 'nick', 'x', 'data']
 RPL_ENDOFWHOIS = retcode(318)
 RPL_ENDOFWHOIS.name = "RPL_ENDOFWHOIS"
 RPL_ENDOFWHOIS.re = (
-    "^:(?P<srv>\S+) 318 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 318 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_ENDOFWHOIS.tpl = (
     ':{c.srv} 318 {c.nick} '
     '{nick} :End of /WHOIS list')
@@ -447,8 +447,8 @@ RPL_ENDOFWHOIS.params = ['srv', 'me', 'nick', 'data']
 RPL_WHOISCHANNELS = retcode(319)
 RPL_WHOISCHANNELS.name = "RPL_WHOISCHANNELS"
 RPL_WHOISCHANNELS.re = (
-    "^:(?P<srv>\S+) 319 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 319 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_WHOISCHANNELS.tpl = (
     ':{c.srv} 319 {c.nick} '
     ':{channels}')
@@ -457,8 +457,8 @@ RPL_WHOISCHANNELS.params = ['srv', 'me', 'data']
 RPL_LISTSTART = retcode(321)
 RPL_LISTSTART.name = "RPL_LISTSTART"
 RPL_LISTSTART.re = (
-    "^:(?P<srv>\S+) 321 (?P<me>\S+) "
-    "Channel :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 321 (?P<me>\S+) "
+    r"Channel :(?P<data>.*)")
 RPL_LISTSTART.tpl = (
     ':{c.srv} 321 {c.nick} '
     'Channel :Users  Name')
@@ -467,8 +467,8 @@ RPL_LISTSTART.params = ['srv', 'me', 'data']
 RPL_LIST = retcode(322)
 RPL_LIST.name = "RPL_LIST"
 RPL_LIST.re = (
-    "^:(?P<srv>\S+) 322 (?P<me>\S+) "
-    "(?P<channel>\S+) (?P<visible>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 322 (?P<me>\S+) "
+    r"(?P<channel>\S+) (?P<visible>\S+) :(?P<data>.*)")
 RPL_LIST.tpl = (
     ':{c.srv} 322 {c.nick} '
     '{channel} {visible} :{topic}')
@@ -477,8 +477,8 @@ RPL_LIST.params = ['srv', 'me', 'channel', 'visible', 'data']
 RPL_LISTEND = retcode(323)
 RPL_LISTEND.name = "RPL_LISTEND"
 RPL_LISTEND.re = (
-    "^:(?P<srv>\S+) 323 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 323 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_LISTEND.tpl = (
     ':{c.srv} 323 {c.nick} '
     ':End of /LIST')
@@ -487,8 +487,8 @@ RPL_LISTEND.params = ['srv', 'me', 'data']
 RPL_CHANNELMODEIS = retcode(324)
 RPL_CHANNELMODEIS.name = "RPL_CHANNELMODEIS"
 RPL_CHANNELMODEIS.re = (
-    "^:(?P<srv>\S+) 324 (?P<me>\S+) "
-    "(?P<channel>\S+) (?P<mode>\S+) (?P<mode_params>\S+)")
+    r"^:(?P<srv>\S+) 324 (?P<me>\S+) "
+    r"(?P<channel>\S+) (?P<mode>\S+) (?P<mode_params>\S+)")
 RPL_CHANNELMODEIS.tpl = (
     ':{c.srv} 324 {c.nick} '
     '{channel} {mode} {mode_params}')
@@ -497,8 +497,8 @@ RPL_CHANNELMODEIS.params = ['srv', 'me', 'channel', 'mode', 'mode_params']
 RPL_NOTOPIC = retcode(331)
 RPL_NOTOPIC.name = "RPL_NOTOPIC"
 RPL_NOTOPIC.re = (
-    "^:(?P<srv>\S+) 331 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 331 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 RPL_NOTOPIC.tpl = (
     ':{c.srv} 331 {c.nick} '
     '{channel} :No topic is set')
@@ -507,8 +507,8 @@ RPL_NOTOPIC.params = ['srv', 'me', 'channel', 'data']
 RPL_TOPIC = retcode(332)
 RPL_TOPIC.name = "RPL_TOPIC"
 RPL_TOPIC.re = (
-    "^:(?P<srv>\S+) 332 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 332 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 RPL_TOPIC.tpl = (
     ':{c.srv} 332 {c.nick} '
     '{channel} :{topic}')
@@ -517,8 +517,8 @@ RPL_TOPIC.params = ['srv', 'me', 'channel', 'data']
 RPL_INVITING = retcode(341)
 RPL_INVITING.name = "RPL_INVITING"
 RPL_INVITING.re = (
-    "^:(?P<srv>\S+) 341 (?P<me>\S+) "
-    "(?P<channel>\S+) (?P<nick>\S+)")
+    r"^:(?P<srv>\S+) 341 (?P<me>\S+) "
+    r"(?P<channel>\S+) (?P<nick>\S+)")
 RPL_INVITING.tpl = (
     ':{c.srv} 341 {c.nick} '
     '{channel} {nick}')
@@ -527,8 +527,8 @@ RPL_INVITING.params = ['srv', 'me', 'channel', 'nick']
 RPL_SUMMONING = retcode(342)
 RPL_SUMMONING.name = "RPL_SUMMONING"
 RPL_SUMMONING.re = (
-    "^:(?P<srv>\S+) 342 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 342 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_SUMMONING.tpl = (
     ':{c.srv} 342 {c.nick} '
     '{nick} :Summoning user to IRC')
@@ -537,9 +537,9 @@ RPL_SUMMONING.params = ['srv', 'me', 'nick', 'data']
 RPL_VERSION = retcode(351)
 RPL_VERSION.name = "RPL_VERSION"
 RPL_VERSION.re = (
-    "^:(?P<srv>\S+) 351 (?P<me>\S+) "
-    "(?P<version>\S+).(?P<debuglevel>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 351 (?P<me>\S+) "
+    r"(?P<version>\S+).(?P<debuglevel>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 RPL_VERSION.tpl = (
     ':{c.srv} 351 {c.nick} '
     '{version}.{debuglevel} {server} :{comments}')
@@ -548,9 +548,9 @@ RPL_VERSION.params = ['srv', 'me', 'version', 'debuglevel', 'server', 'data']
 RPL_WHOREPLY = retcode(352)
 RPL_WHOREPLY.name = "RPL_WHOREPLY"
 RPL_WHOREPLY.re = (
-    "^:(?P<srv>\S+) 352 (?P<me>\S+) "
-    "(?P<channel>\S+) (?P<username>\S+) (?P<host>\S+) "
-    "(?P<server>\S+) (?P<nick>\S+) (?P<modes>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 352 (?P<me>\S+) "
+    r"(?P<channel>\S+) (?P<username>\S+) (?P<host>\S+) "
+    r"(?P<server>\S+) (?P<nick>\S+) (?P<modes>\S+) :(?P<data>.*)")
 RPL_WHOREPLY.tpl = (
     ':{c.srv} 352 {c.nick} '
     ':{channel} {username} {host} {server} {nick} {modes} '
@@ -569,8 +569,8 @@ RPL_WHOREPLY.params = [
 RPL_NAMREPLY = retcode(353)
 RPL_NAMREPLY.name = "RPL_NAMREPLY"
 RPL_NAMREPLY.re = (
-    "^:(?P<srv>\S+) 353 (?P<me>\S+) "
-    "(?P<m>\S+) (?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 353 (?P<me>\S+) "
+    r"(?P<m>\S+) (?P<channel>\S+) :(?P<data>.*)")
 RPL_NAMREPLY.tpl = (
     ':{c.srv} 353 {c.nick} '
     '{m} {channel} :{nicknames}')
@@ -579,9 +579,9 @@ RPL_NAMREPLY.params = ['srv', 'me', 'm', 'channel', 'data']
 RPL_LINKS = retcode(364)
 RPL_LINKS.name = "RPL_LINKS"
 RPL_LINKS.re = (
-    "^:(?P<srv>\S+) 364 (?P<me>\S+) "
-    "(?P<mask>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 364 (?P<me>\S+) "
+    r"(?P<mask>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 RPL_LINKS.tpl = (
     ':{c.srv} 364 {c.nick} '
     '{mask} {server} :{hopcount} {server_info}')
@@ -590,8 +590,8 @@ RPL_LINKS.params = ['srv', 'me', 'mask', 'server', 'data']
 RPL_ENDOFLINKS = retcode(365)
 RPL_ENDOFLINKS.name = "RPL_ENDOFLINKS"
 RPL_ENDOFLINKS.re = (
-    "^:(?P<srv>\S+) 365 (?P<me>\S+) "
-    "(?P<mask>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 365 (?P<me>\S+) "
+    r"(?P<mask>\S+) :(?P<data>.*)")
 RPL_ENDOFLINKS.tpl = (
     ':{c.srv} 365 {c.nick} '
     '{mask} :End of /LINKS list')
@@ -600,8 +600,8 @@ RPL_ENDOFLINKS.params = ['srv', 'me', 'mask', 'data']
 RPL_ENDOFNAMES = retcode(366)
 RPL_ENDOFNAMES.name = "RPL_ENDOFNAMES"
 RPL_ENDOFNAMES.re = (
-    "^:(?P<srv>\S+) 366 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 366 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 RPL_ENDOFNAMES.tpl = (
     ':{c.srv} 366 {c.nick} '
     '{channel} :End of /NAMES list')
@@ -610,8 +610,8 @@ RPL_ENDOFNAMES.params = ['srv', 'me', 'channel', 'data']
 RPL_BANLIST = retcode(367)
 RPL_BANLIST.name = "RPL_BANLIST"
 RPL_BANLIST.re = (
-    "^:(?P<srv>\S+) 367 (?P<me>\S+) "
-    "(?P<channel>\S+) (?P<banid>\S+)")
+    r"^:(?P<srv>\S+) 367 (?P<me>\S+) "
+    r"(?P<channel>\S+) (?P<banid>\S+)")
 RPL_BANLIST.tpl = (
     ':{c.srv} 367 {c.nick} '
     '{channel} {banid}')
@@ -620,8 +620,8 @@ RPL_BANLIST.params = ['srv', 'me', 'channel', 'banid']
 RPL_ENDOFBANLIST = retcode(368)
 RPL_ENDOFBANLIST.name = "RPL_ENDOFBANLIST"
 RPL_ENDOFBANLIST.re = (
-    "^:(?P<srv>\S+) 368 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 368 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 RPL_ENDOFBANLIST.tpl = (
     ':{c.srv} 368 {c.nick} '
     '{channel} :End of channel ban list')
@@ -630,8 +630,8 @@ RPL_ENDOFBANLIST.params = ['srv', 'me', 'channel', 'data']
 RPL_ENDOFWHOWAS = retcode(369)
 RPL_ENDOFWHOWAS.name = "RPL_ENDOFWHOWAS"
 RPL_ENDOFWHOWAS.re = (
-    "^:(?P<srv>\S+) 369 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 369 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 RPL_ENDOFWHOWAS.tpl = (
     ':{c.srv} 369 {c.nick} '
     '{nick} :End of WHOWAS')
@@ -640,8 +640,8 @@ RPL_ENDOFWHOWAS.params = ['srv', 'me', 'nick', 'data']
 RPL_INFO = retcode(371)
 RPL_INFO.name = "RPL_INFO"
 RPL_INFO.re = (
-    "^:(?P<srv>\S+) 371 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 371 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_INFO.tpl = (
     ':{c.srv} 371 {c.nick} '
     ':{string}')
@@ -650,8 +650,8 @@ RPL_INFO.params = ['srv', 'me', 'data']
 RPL_MOTD = retcode(372)
 RPL_MOTD.name = "RPL_MOTD"
 RPL_MOTD.re = (
-    "^:(?P<srv>\S+) 372 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 372 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_MOTD.tpl = (
     ':{c.srv} 372 {c.nick} '
     ':- {text}')
@@ -660,8 +660,8 @@ RPL_MOTD.params = ['srv', 'me', 'data']
 RPL_ENDOFINFO = retcode(374)
 RPL_ENDOFINFO.name = "RPL_ENDOFINFO"
 RPL_ENDOFINFO.re = (
-    "^:(?P<srv>\S+) 374 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 374 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ENDOFINFO.tpl = (
     ':{c.srv} 374 {c.nick} '
     ':End of /INFO list')
@@ -670,8 +670,8 @@ RPL_ENDOFINFO.params = ['srv', 'me', 'data']
 RPL_MOTDSTART = retcode(375)
 RPL_MOTDSTART.name = "RPL_MOTDSTART"
 RPL_MOTDSTART.re = (
-    "^:(?P<srv>\S+) 375 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 375 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_MOTDSTART.tpl = (
     ':{c.srv} 375 {c.nick} '
     ':- {server} Message of the day -')
@@ -680,8 +680,8 @@ RPL_MOTDSTART.params = ['srv', 'me', 'data']
 RPL_ENDOFMOTD = retcode(376)
 RPL_ENDOFMOTD.name = "RPL_ENDOFMOTD"
 RPL_ENDOFMOTD.re = (
-    "^:(?P<srv>\S+) 376 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 376 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ENDOFMOTD.tpl = (
     ':{c.srv} 376 {c.nick} '
     ':End of /MOTD command')
@@ -690,8 +690,8 @@ RPL_ENDOFMOTD.params = ['srv', 'me', 'data']
 RPL_YOUREOPER = retcode(381)
 RPL_YOUREOPER.name = "RPL_YOUREOPER"
 RPL_YOUREOPER.re = (
-    "^:(?P<srv>\S+) 381 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 381 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_YOUREOPER.tpl = (
     ':{c.srv} 381 {c.nick} '
     ':You are now an IRC operator')
@@ -700,8 +700,8 @@ RPL_YOUREOPER.params = ['srv', 'me', 'data']
 RPL_REHASHING = retcode(382)
 RPL_REHASHING.name = "RPL_REHASHING"
 RPL_REHASHING.re = (
-    "^:(?P<srv>\S+) 382 (?P<me>\S+) "
-    "(?P<config_file>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 382 (?P<me>\S+) "
+    r"(?P<config_file>\S+) :(?P<data>.*)")
 RPL_REHASHING.tpl = (
     ':{c.srv} 382 {c.nick} '
     '{config_file} :Rehashing')
@@ -710,8 +710,8 @@ RPL_REHASHING.params = ['srv', 'me', 'config_file', 'data']
 RPL_TIME = retcode(391)
 RPL_TIME.name = "RPL_TIME"
 RPL_TIME.re = (
-    "^:(?P<srv>\S+) 391 (?P<me>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 391 (?P<me>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 RPL_TIME.tpl = (
     ':{c.srv} 391 {c.nick} '
     "{server} :{string_showing_server's_local_time}")
@@ -720,8 +720,8 @@ RPL_TIME.params = ['srv', 'me', 'server', 'data']
 RPL_USERSSTART = retcode(392)
 RPL_USERSSTART.name = "RPL_USERSSTART"
 RPL_USERSSTART.re = (
-    "^:(?P<srv>\S+) 392 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 392 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_USERSSTART.tpl = (
     ':{c.srv} 392 {c.nick} '
     ':UserID   Terminal  Host')
@@ -730,8 +730,8 @@ RPL_USERSSTART.params = ['srv', 'me', 'data']
 RPL_USERS = retcode(393)
 RPL_USERS.name = "RPL_USERS"
 RPL_USERS.re = (
-    "^:(?P<srv>\S+) 393 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 393 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_USERS.tpl = (
     ':{c.srv} 393 {c.nick} '
     '{x} {y} {z}')
@@ -740,8 +740,8 @@ RPL_USERS.params = ['srv', 'me', 'data']
 RPL_ENDOFUSERS = retcode(394)
 RPL_ENDOFUSERS.name = "RPL_ENDOFUSERS"
 RPL_ENDOFUSERS.re = (
-    "^:(?P<srv>\S+) 394 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 394 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_ENDOFUSERS.tpl = (
     ':{c.srv} 394 {c.nick} '
     ':End of users')
@@ -750,8 +750,8 @@ RPL_ENDOFUSERS.params = ['srv', 'me', 'data']
 RPL_NOUSERS = retcode(395)
 RPL_NOUSERS.name = "RPL_NOUSERS"
 RPL_NOUSERS.re = (
-    "^:(?P<srv>\S+) 395 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 395 (?P<me>\S+) "
+    r":(?P<data>.*)")
 RPL_NOUSERS.tpl = (
     ':{c.srv} 395 {c.nick} '
     ':Nobody logged in')
@@ -760,8 +760,8 @@ RPL_NOUSERS.params = ['srv', 'me', 'data']
 ERR_NOSUCHNICK = retcode(401)
 ERR_NOSUCHNICK.name = "ERR_NOSUCHNICK"
 ERR_NOSUCHNICK.re = (
-    "^:(?P<srv>\S+) 401 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 401 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_NOSUCHNICK.tpl = (
     ':{c.srv} 401 {c.nick} '
     '{nick} :No such nick/channel')
@@ -770,8 +770,8 @@ ERR_NOSUCHNICK.params = ['srv', 'me', 'nick', 'data']
 ERR_NOSUCHSERVER = retcode(402)
 ERR_NOSUCHSERVER.name = "ERR_NOSUCHSERVER"
 ERR_NOSUCHSERVER.re = (
-    "^:(?P<srv>\S+) 402 (?P<me>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 402 (?P<me>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 ERR_NOSUCHSERVER.tpl = (
     ':{c.srv} 402 {c.nick} '
     '{server} :No such server')
@@ -780,8 +780,8 @@ ERR_NOSUCHSERVER.params = ['srv', 'me', 'server', 'data']
 ERR_NOSUCHCHANNEL = retcode(403)
 ERR_NOSUCHCHANNEL.name = "ERR_NOSUCHCHANNEL"
 ERR_NOSUCHCHANNEL.re = (
-    "^:(?P<srv>\S+) 403 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 403 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_NOSUCHCHANNEL.tpl = (
     ':{c.srv} 403 {c.nick} '
     '{channel} :No such channel')
@@ -790,8 +790,8 @@ ERR_NOSUCHCHANNEL.params = ['srv', 'me', 'channel', 'data']
 ERR_CANNOTSENDTOCHAN = retcode(404)
 ERR_CANNOTSENDTOCHAN.name = "ERR_CANNOTSENDTOCHAN"
 ERR_CANNOTSENDTOCHAN.re = (
-    "^:(?P<srv>\S+) 404 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 404 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_CANNOTSENDTOCHAN.tpl = (
     ':{c.srv} 404 {c.nick} '
     '{channel} :Cannot send to channel')
@@ -800,8 +800,8 @@ ERR_CANNOTSENDTOCHAN.params = ['srv', 'me', 'channel', 'data']
 ERR_TOOMANYCHANNELS = retcode(405)
 ERR_TOOMANYCHANNELS.name = "ERR_TOOMANYCHANNELS"
 ERR_TOOMANYCHANNELS.re = (
-    "^:(?P<srv>\S+) 405 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 405 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_TOOMANYCHANNELS.tpl = (
     ':{c.srv} 405 {c.nick} '
     '{channel} :You have joined too many channels')
@@ -810,8 +810,8 @@ ERR_TOOMANYCHANNELS.params = ['srv', 'me', 'channel', 'data']
 ERR_WASNOSUCHNICK = retcode(406)
 ERR_WASNOSUCHNICK.name = "ERR_WASNOSUCHNICK"
 ERR_WASNOSUCHNICK.re = (
-    "^:(?P<srv>\S+) 406 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 406 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_WASNOSUCHNICK.tpl = (
     ':{c.srv} 406 {c.nick} '
     '{nick} :There was no such nickname')
@@ -820,8 +820,8 @@ ERR_WASNOSUCHNICK.params = ['srv', 'me', 'nick', 'data']
 ERR_TOOMANYTARGETS = retcode(407)
 ERR_TOOMANYTARGETS.name = "ERR_TOOMANYTARGETS"
 ERR_TOOMANYTARGETS.re = (
-    "^:(?P<srv>\S+) 407 (?P<me>\S+) "
-    "(?P<target>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 407 (?P<me>\S+) "
+    r"(?P<target>\S+) :(?P<data>.*)")
 ERR_TOOMANYTARGETS.tpl = (
     ':{c.srv} 407 {c.nick} '
     '{target} :Duplicate recipients. No message delivered')
@@ -830,8 +830,8 @@ ERR_TOOMANYTARGETS.params = ['srv', 'me', 'target', 'data']
 ERR_NOORIGIN = retcode(409)
 ERR_NOORIGIN.name = "ERR_NOORIGIN"
 ERR_NOORIGIN.re = (
-    "^:(?P<srv>\S+) 409 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 409 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOORIGIN.tpl = (
     ':{c.srv} 409 {c.nick} '
     ':No origin specified')
@@ -840,8 +840,8 @@ ERR_NOORIGIN.params = ['srv', 'me', 'data']
 ERR_NORECIPIENT = retcode(411)
 ERR_NORECIPIENT.name = "ERR_NORECIPIENT"
 ERR_NORECIPIENT.re = (
-    "^:(?P<srv>\S+) 411 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 411 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NORECIPIENT.tpl = (
     ':{c.srv} 411 {c.nick} '
     ':No recipient given ({cmd})')
@@ -850,8 +850,8 @@ ERR_NORECIPIENT.params = ['srv', 'me', 'data']
 ERR_NOTEXTTOSEND = retcode(412)
 ERR_NOTEXTTOSEND.name = "ERR_NOTEXTTOSEND"
 ERR_NOTEXTTOSEND.re = (
-    "^:(?P<srv>\S+) 412 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 412 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOTEXTTOSEND.tpl = (
     ':{c.srv} 412 {c.nick} '
     ':No text to send')
@@ -860,8 +860,8 @@ ERR_NOTEXTTOSEND.params = ['srv', 'me', 'data']
 ERR_NOTOPLEVEL = retcode(413)
 ERR_NOTOPLEVEL.name = "ERR_NOTOPLEVEL"
 ERR_NOTOPLEVEL.re = (
-    "^:(?P<srv>\S+) 413 (?P<me>\S+) "
-    "(?P<mask>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 413 (?P<me>\S+) "
+    r"(?P<mask>\S+) :(?P<data>.*)")
 ERR_NOTOPLEVEL.tpl = (
     ':{c.srv} 413 {c.nick} '
     '{mask} :No toplevel domain specified')
@@ -870,8 +870,8 @@ ERR_NOTOPLEVEL.params = ['srv', 'me', 'mask', 'data']
 ERR_WILDTOPLEVEL = retcode(414)
 ERR_WILDTOPLEVEL.name = "ERR_WILDTOPLEVEL"
 ERR_WILDTOPLEVEL.re = (
-    "^:(?P<srv>\S+) 414 (?P<me>\S+) "
-    "(?P<mask>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 414 (?P<me>\S+) "
+    r"(?P<mask>\S+) :(?P<data>.*)")
 ERR_WILDTOPLEVEL.tpl = (
     ':{c.srv} 414 {c.nick} '
     '{mask} :Wildcard in toplevel domain')
@@ -880,8 +880,8 @@ ERR_WILDTOPLEVEL.params = ['srv', 'me', 'mask', 'data']
 ERR_UNKNOWNCOMMAND = retcode(421)
 ERR_UNKNOWNCOMMAND.name = "ERR_UNKNOWNCOMMAND"
 ERR_UNKNOWNCOMMAND.re = (
-    "^:(?P<srv>\S+) 421 (?P<me>\S+) "
-    "(?P<cmd>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 421 (?P<me>\S+) "
+    r"(?P<cmd>\S+) :(?P<data>.*)")
 ERR_UNKNOWNCOMMAND.tpl = (
     ':{c.srv} 421 {c.nick} '
     '{cmd} :Unknown command')
@@ -890,8 +890,8 @@ ERR_UNKNOWNCOMMAND.params = ['srv', 'me', 'cmd', 'data']
 ERR_NOMOTD = retcode(422)
 ERR_NOMOTD.name = "ERR_NOMOTD"
 ERR_NOMOTD.re = (
-    "^:(?P<srv>\S+) 422 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 422 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOMOTD.tpl = (
     ':{c.srv} 422 {c.nick} '
     ':MOTD File is missing')
@@ -900,8 +900,8 @@ ERR_NOMOTD.params = ['srv', 'me', 'data']
 ERR_NOADMININFO = retcode(423)
 ERR_NOADMININFO.name = "ERR_NOADMININFO"
 ERR_NOADMININFO.re = (
-    "^:(?P<srv>\S+) 423 (?P<me>\S+) "
-    "(?P<server>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 423 (?P<me>\S+) "
+    r"(?P<server>\S+) :(?P<data>.*)")
 ERR_NOADMININFO.tpl = (
     ':{c.srv} 423 {c.nick} '
     '{server} :No administrative info available')
@@ -910,8 +910,8 @@ ERR_NOADMININFO.params = ['srv', 'me', 'server', 'data']
 ERR_NONICKNAMEGIVEN = retcode(431)
 ERR_NONICKNAMEGIVEN.name = "ERR_NONICKNAMEGIVEN"
 ERR_NONICKNAMEGIVEN.re = (
-    "^:(?P<srv>\S+) 431 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 431 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NONICKNAMEGIVEN.tpl = (
     ':{c.srv} 431 {c.nick} '
     ':No nickname given')
@@ -920,8 +920,8 @@ ERR_NONICKNAMEGIVEN.params = ['srv', 'me', 'data']
 ERR_ERRONEUSNICKNAME = retcode(432)
 ERR_ERRONEUSNICKNAME.name = "ERR_ERRONEUSNICKNAME"
 ERR_ERRONEUSNICKNAME.re = (
-    "^:(?P<srv>\S+) 432 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 432 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_ERRONEUSNICKNAME.tpl = (
     ':{c.srv} 432 {c.nick} '
     '{nick} :Erroneus nickname')
@@ -930,8 +930,8 @@ ERR_ERRONEUSNICKNAME.params = ['srv', 'me', 'nick', 'data']
 ERR_NICKNAMEINUSE = retcode(433)
 ERR_NICKNAMEINUSE.name = "ERR_NICKNAMEINUSE"
 ERR_NICKNAMEINUSE.re = (
-    "^:(?P<srv>\S+) 433 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 433 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_NICKNAMEINUSE.tpl = (
     ':{c.srv} 433 {c.nick} '
     '{nick} :Nickname is already in use')
@@ -940,8 +940,8 @@ ERR_NICKNAMEINUSE.params = ['srv', 'me', 'nick', 'data']
 ERR_NICKCOLLISION = retcode(436)
 ERR_NICKCOLLISION.name = "ERR_NICKCOLLISION"
 ERR_NICKCOLLISION.re = (
-    "^:(?P<srv>\S+) 436 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 436 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_NICKCOLLISION.tpl = (
     ':{c.srv} 436 {c.nick} '
     '{nick} :Nickname collision KILL')
@@ -950,8 +950,8 @@ ERR_NICKCOLLISION.params = ['srv', 'me', 'nick', 'data']
 ERR_USERNOTINCHANNEL = retcode(441)
 ERR_USERNOTINCHANNEL.name = "ERR_USERNOTINCHANNEL"
 ERR_USERNOTINCHANNEL.re = (
-    "^:(?P<srv>\S+) 441 (?P<me>\S+) "
-    "(?P<nick>\S+) (?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 441 (?P<me>\S+) "
+    r"(?P<nick>\S+) (?P<channel>\S+) :(?P<data>.*)")
 ERR_USERNOTINCHANNEL.tpl = (
     ':{c.srv} 441 {c.nick} '
     "{nick} {channel} :They aren't on that channel")
@@ -960,8 +960,8 @@ ERR_USERNOTINCHANNEL.params = ['srv', 'me', 'nick', 'channel', 'data']
 ERR_NOTONCHANNEL = retcode(442)
 ERR_NOTONCHANNEL.name = "ERR_NOTONCHANNEL"
 ERR_NOTONCHANNEL.re = (
-    "^:(?P<srv>\S+) 442 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 442 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_NOTONCHANNEL.tpl = (
     ':{c.srv} 442 {c.nick} '
     "{channel} :You're not on that channel")
@@ -970,8 +970,8 @@ ERR_NOTONCHANNEL.params = ['srv', 'me', 'channel', 'data']
 ERR_USERONCHANNEL = retcode(443)
 ERR_USERONCHANNEL.name = "ERR_USERONCHANNEL"
 ERR_USERONCHANNEL.re = (
-    "^:(?P<srv>\S+) 443 (?P<me>\S+) "
-    "(?P<nick>\S+) (?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 443 (?P<me>\S+) "
+    r"(?P<nick>\S+) (?P<channel>\S+) :(?P<data>.*)")
 ERR_USERONCHANNEL.tpl = (
     ':{c.srv} 443 {c.nick} '
     '{nick} {channel} :is already on channel')
@@ -980,8 +980,8 @@ ERR_USERONCHANNEL.params = ['srv', 'me', 'nick', 'channel', 'data']
 ERR_NOLOGIN = retcode(444)
 ERR_NOLOGIN.name = "ERR_NOLOGIN"
 ERR_NOLOGIN.re = (
-    "^:(?P<srv>\S+) 444 (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 444 (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")
 ERR_NOLOGIN.tpl = (
     ':{c.srv} 444 {c.nick} '
     '{nick} :User not logged in')
@@ -990,8 +990,8 @@ ERR_NOLOGIN.params = ['srv', 'me', 'nick', 'data']
 ERR_SUMMONDISABLED = retcode(445)
 ERR_SUMMONDISABLED.name = "ERR_SUMMONDISABLED"
 ERR_SUMMONDISABLED.re = (
-    "^:(?P<srv>\S+) 445 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 445 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_SUMMONDISABLED.tpl = (
     ':{c.srv} 445 {c.nick} '
     ':SUMMON has been disabled')
@@ -1000,8 +1000,8 @@ ERR_SUMMONDISABLED.params = ['srv', 'me', 'data']
 ERR_USERSDISABLED = retcode(446)
 ERR_USERSDISABLED.name = "ERR_USERSDISABLED"
 ERR_USERSDISABLED.re = (
-    "^:(?P<srv>\S+) 446 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 446 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_USERSDISABLED.tpl = (
     ':{c.srv} 446 {c.nick} '
     ':USERS has been disabled')
@@ -1010,8 +1010,8 @@ ERR_USERSDISABLED.params = ['srv', 'me', 'data']
 ERR_NOTREGISTERED = retcode(451)
 ERR_NOTREGISTERED.name = "ERR_NOTREGISTERED"
 ERR_NOTREGISTERED.re = (
-    "^:(?P<srv>\S+) 451 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 451 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOTREGISTERED.tpl = (
     ':{c.srv} 451 {c.nick} '
     ':You have not registered')
@@ -1020,8 +1020,8 @@ ERR_NOTREGISTERED.params = ['srv', 'me', 'data']
 ERR_NEEDMOREPARAMS = retcode(461)
 ERR_NEEDMOREPARAMS.name = "ERR_NEEDMOREPARAMS"
 ERR_NEEDMOREPARAMS.re = (
-    "^:(?P<srv>\S+) 461 (?P<me>\S+) "
-    "(?P<cmd>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 461 (?P<me>\S+) "
+    r"(?P<cmd>\S+) :(?P<data>.*)")
 ERR_NEEDMOREPARAMS.tpl = (
     ':{c.srv} 461 {c.nick} '
     '{cmd} :Not enough parameters')
@@ -1030,8 +1030,8 @@ ERR_NEEDMOREPARAMS.params = ['srv', 'me', 'cmd', 'data']
 ERR_ALREADYREGISTRED = retcode(462)
 ERR_ALREADYREGISTRED.name = "ERR_ALREADYREGISTRED"
 ERR_ALREADYREGISTRED.re = (
-    "^:(?P<srv>\S+) 462 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 462 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_ALREADYREGISTRED.tpl = (
     ':{c.srv} 462 {c.nick} '
     ':You may not reregister')
@@ -1040,8 +1040,8 @@ ERR_ALREADYREGISTRED.params = ['srv', 'me', 'data']
 ERR_NOPERMFORHOST = retcode(463)
 ERR_NOPERMFORHOST.name = "ERR_NOPERMFORHOST"
 ERR_NOPERMFORHOST.re = (
-    "^:(?P<srv>\S+) 463 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 463 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOPERMFORHOST.tpl = (
     ':{c.srv} 463 {c.nick} '
     ":Your host isn't among the privileged")
@@ -1050,8 +1050,8 @@ ERR_NOPERMFORHOST.params = ['srv', 'me', 'data']
 ERR_PASSWDMISMATCH = retcode(464)
 ERR_PASSWDMISMATCH.name = "ERR_PASSWDMISMATCH"
 ERR_PASSWDMISMATCH.re = (
-    "^:(?P<srv>\S+) 464 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 464 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_PASSWDMISMATCH.tpl = (
     ':{c.srv} 464 {c.nick} '
     ':Password incorrect')
@@ -1060,8 +1060,8 @@ ERR_PASSWDMISMATCH.params = ['srv', 'me', 'data']
 ERR_YOUREBANNEDCREEP = retcode(465)
 ERR_YOUREBANNEDCREEP.name = "ERR_YOUREBANNEDCREEP"
 ERR_YOUREBANNEDCREEP.re = (
-    "^:(?P<srv>\S+) 465 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 465 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_YOUREBANNEDCREEP.tpl = (
     ':{c.srv} 465 {c.nick} '
     ':You are banned from this server')
@@ -1070,8 +1070,8 @@ ERR_YOUREBANNEDCREEP.params = ['srv', 'me', 'data']
 ERR_KEYSET = retcode(467)
 ERR_KEYSET.name = "ERR_KEYSET"
 ERR_KEYSET.re = (
-    "^:(?P<srv>\S+) 467 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 467 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_KEYSET.tpl = (
     ':{c.srv} 467 {c.nick} '
     '{channel} :Channel key already set')
@@ -1080,8 +1080,8 @@ ERR_KEYSET.params = ['srv', 'me', 'channel', 'data']
 ERR_CHANNELISFULL = retcode(471)
 ERR_CHANNELISFULL.name = "ERR_CHANNELISFULL"
 ERR_CHANNELISFULL.re = (
-    "^:(?P<srv>\S+) 471 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 471 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_CHANNELISFULL.tpl = (
     ':{c.srv} 471 {c.nick} '
     '{channel} :Cannot join channel (+l)')
@@ -1090,8 +1090,8 @@ ERR_CHANNELISFULL.params = ['srv', 'me', 'channel', 'data']
 ERR_UNKNOWNMODE = retcode(472)
 ERR_UNKNOWNMODE.name = "ERR_UNKNOWNMODE"
 ERR_UNKNOWNMODE.re = (
-    "^:(?P<srv>\S+) 472 (?P<me>\S+) "
-    "(?P<char>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 472 (?P<me>\S+) "
+    r"(?P<char>\S+) :(?P<data>.*)")
 ERR_UNKNOWNMODE.tpl = (
     ':{c.srv} 472 {c.nick} '
     '{char} :is unknown mode char to me')
@@ -1100,8 +1100,8 @@ ERR_UNKNOWNMODE.params = ['srv', 'me', 'char', 'data']
 ERR_INVITEONLYCHAN = retcode(473)
 ERR_INVITEONLYCHAN.name = "ERR_INVITEONLYCHAN"
 ERR_INVITEONLYCHAN.re = (
-    "^:(?P<srv>\S+) 473 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 473 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_INVITEONLYCHAN.tpl = (
     ':{c.srv} 473 {c.nick} '
     '{channel} :Cannot join channel (+i)')
@@ -1110,8 +1110,8 @@ ERR_INVITEONLYCHAN.params = ['srv', 'me', 'channel', 'data']
 ERR_BANNEDFROMCHAN = retcode(474)
 ERR_BANNEDFROMCHAN.name = "ERR_BANNEDFROMCHAN"
 ERR_BANNEDFROMCHAN.re = (
-    "^:(?P<srv>\S+) 474 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 474 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_BANNEDFROMCHAN.tpl = (
     ':{c.srv} 474 {c.nick} '
     '{channel} :Cannot join channel (+b)')
@@ -1120,8 +1120,8 @@ ERR_BANNEDFROMCHAN.params = ['srv', 'me', 'channel', 'data']
 ERR_BADCHANNELKEY = retcode(475)
 ERR_BADCHANNELKEY.name = "ERR_BADCHANNELKEY"
 ERR_BADCHANNELKEY.re = (
-    "^:(?P<srv>\S+) 475 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 475 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_BADCHANNELKEY.tpl = (
     ':{c.srv} 475 {c.nick} '
     '{channel} :Cannot join channel (+k)')
@@ -1130,8 +1130,8 @@ ERR_BADCHANNELKEY.params = ['srv', 'me', 'channel', 'data']
 ERR_NOPRIVILEGES = retcode(481)
 ERR_NOPRIVILEGES.name = "ERR_NOPRIVILEGES"
 ERR_NOPRIVILEGES.re = (
-    "^:(?P<srv>\S+) 481 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 481 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOPRIVILEGES.tpl = (
     ':{c.srv} 481 {c.nick} '
     ":Permission Denied- You're not an IRC operator")
@@ -1140,8 +1140,8 @@ ERR_NOPRIVILEGES.params = ['srv', 'me', 'data']
 ERR_CHANOPRIVSNEEDED = retcode(482)
 ERR_CHANOPRIVSNEEDED.name = "ERR_CHANOPRIVSNEEDED"
 ERR_CHANOPRIVSNEEDED.re = (
-    "^:(?P<srv>\S+) 482 (?P<me>\S+) "
-    "(?P<channel>\S+) :(?P<data>.*)")
+    r"^:(?P<srv>\S+) 482 (?P<me>\S+) "
+    r"(?P<channel>\S+) :(?P<data>.*)")
 ERR_CHANOPRIVSNEEDED.tpl = (
     ':{c.srv} 482 {c.nick} '
     "{channel} :You're not channel operator")
@@ -1150,8 +1150,8 @@ ERR_CHANOPRIVSNEEDED.params = ['srv', 'me', 'channel', 'data']
 ERR_CANTKILLSERVER = retcode(483)
 ERR_CANTKILLSERVER.name = "ERR_CANTKILLSERVER"
 ERR_CANTKILLSERVER.re = (
-    "^:(?P<srv>\S+) 483 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 483 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_CANTKILLSERVER.tpl = (
     ':{c.srv} 483 {c.nick} '
     ':You cant kill a server!')
@@ -1160,8 +1160,8 @@ ERR_CANTKILLSERVER.params = ['srv', 'me', 'data']
 ERR_NOOPERHOST = retcode(491)
 ERR_NOOPERHOST.name = "ERR_NOOPERHOST"
 ERR_NOOPERHOST.re = (
-    "^:(?P<srv>\S+) 491 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 491 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_NOOPERHOST.tpl = (
     ':{c.srv} 491 {c.nick} '
     ':No O-lines for your host')
@@ -1170,8 +1170,8 @@ ERR_NOOPERHOST.params = ['srv', 'me', 'data']
 ERR_UMODEUNKNOWNFLAG = retcode(501)
 ERR_UMODEUNKNOWNFLAG.name = "ERR_UMODEUNKNOWNFLAG"
 ERR_UMODEUNKNOWNFLAG.re = (
-    "^:(?P<srv>\S+) 501 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 501 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_UMODEUNKNOWNFLAG.tpl = (
     ':{c.srv} 501 {c.nick} '
     ':Unknown MODE flag')
@@ -1180,8 +1180,8 @@ ERR_UMODEUNKNOWNFLAG.params = ['srv', 'me', 'data']
 ERR_USERSDONTMATCH = retcode(502)
 ERR_USERSDONTMATCH.name = "ERR_USERSDONTMATCH"
 ERR_USERSDONTMATCH.re = (
-    "^:(?P<srv>\S+) 502 (?P<me>\S+) "
-    ":(?P<data>.*)")
+    r"^:(?P<srv>\S+) 502 (?P<me>\S+) "
+    r":(?P<data>.*)")
 ERR_USERSDONTMATCH.tpl = (
     ':{c.srv} 502 {c.nick} '
     ':Cant change mode for other users')

--- a/irc3/dec.py
+++ b/irc3/dec.py
@@ -13,7 +13,7 @@ def plugin(wrapped):
 
 
 class event:
-    """register a method or function an irc event callback::
+    r"""register a method or function an irc event callback::
 
         >>> @event('^:\S+ 353 [^&#]+(?P<channel>\S+) :(?P<nicknames>.*)')
         ... def on_names(bot, channel=None, nicknames=None):

--- a/irc3/plugins/asynchronious.py
+++ b/irc3/plugins/asynchronious.py
@@ -75,18 +75,19 @@ class Whois(AsyncEvents):
     # when those events occurs, we can add them to the result list
     events = (
         # (?i) is for IGNORECASE. This will match either NicK or nick
-        {'match': "(?i)^:\S+ 301 \S+ {nick} :(?P<away>.*)"},
-        {'match': "(?i)^:\S+ 311 \S+ {nick} (?P<username>\S+) (?P<host>\S+) . "
-                  ":(?P<realname>.*)(?i)"},
-        {'match': "(?i)^:\S+ 312 \S+ {nick} (?P<server>\S+) "
-                  ":(?P<server_desc>.*)"},
-        {'match': "(?i)^:\S+ 317 \S+ {nick} (?P<idle>[0-9]+).*"},
-        {'match': "(?i)^:\S+ 319 \S+ {nick} :(?P<channels>.*)", 'multi': True},
-        {'match': "(?i)^:\S+ 330 \S+ {nick} (?P<account>\S+) "
-                  ":(?P<account_desc>.*)"},
-        {'match': "(?i)^:\S+ 671 \S+ {nick} :(?P<connection>.*)"},
+        {'match': r"(?i)^:\S+ 301 \S+ {nick} :(?P<away>.*)"},
+        {'match': r"(?i)^:\S+ 311 \S+ {nick} (?P<username>\S+) "
+                  r"(?P<host>\S+) . :(?P<realname>.*)(?i)"},
+        {'match': r"(?i)^:\S+ 312 \S+ {nick} (?P<server>\S+) "
+                  r":(?P<server_desc>.*)"},
+        {'match': r"(?i)^:\S+ 317 \S+ {nick} (?P<idle>[0-9]+).*"},
+        {'match': r"(?i)^:\S+ 319 \S+ {nick} :(?P<channels>.*)",
+         'multi': True},
+        {'match': r"(?i)^:\S+ 330 \S+ {nick} (?P<account>\S+) "
+                  r":(?P<account_desc>.*)"},
+        {'match': r"(?i)^:\S+ 671 \S+ {nick} :(?P<connection>.*)"},
         # if final=True then a result is returned when the event occurs
-        {'match': "(?i)^:\S+ (?P<retcode>(318|401)) \S+ (?P<nick>{nick}) :.*",
+        {'match': r"(?i)^:\S+ (?P<retcode>(318|401)) \S+ (?P<nick>{nick}) :.*",
          'final': True},
     )
 
@@ -106,11 +107,11 @@ class WhoChannel(AsyncEvents):
     send_line = 'WHO {channel}'
 
     events = (
-        {"match": "(?i)^:\S+ 352 \S+ {channel} (?P<user>\S+) "
-                  "(?P<host>\S+) (?P<server>\S+) (?P<nick>\S+) "
-                  "(?P<modes>\S+) :(?P<hopcount>\S+) (?P<realname>.*)",
+        {"match": r"(?i)^:\S+ 352 \S+ {channel} (?P<user>\S+) "
+                  r"(?P<host>\S+) (?P<server>\S+) (?P<nick>\S+) "
+                  r"(?P<modes>\S+) :(?P<hopcount>\S+) (?P<realname>.*)",
          "multi": True},
-        {"match": "(?i)^:\S+ (?P<retcode>(315|401)) \S+ {channel} :.*",
+        {"match": r"(?i)^:\S+ (?P<retcode>(315|401)) \S+ {channel} :.*",
          "final": True},
     )
 
@@ -131,19 +132,19 @@ class WhoChannel(AsyncEvents):
 class WhoChannelFlags(AsyncEvents):
 
     flags = OrderedDict([
-        ("u", "(?P<user>\S+)"),
-        ("i", "(?P<ip>\S+)"),
-        ("h", "(?P<host>\S+)"),
-        ("s", "(?P<server>\S+)"),
-        ("n", "(?P<nick>\S+)"),
-        ("a", "(?P<account>\S+)"),
-        ("r", ":(?P<realname>.*)"),
+        ("u", r"(?P<user>\S+)"),
+        ("i", r"(?P<ip>\S+)"),
+        ("h", r"(?P<host>\S+)"),
+        ("s", r"(?P<server>\S+)"),
+        ("n", r"(?P<nick>\S+)"),
+        ("a", r"(?P<account>\S+)"),
+        ("r", r":(?P<realname>.*)"),
     ])
 
     send_line = "WHO {channel} c%{flags}"
 
     events = (
-        {"match": "(?i)^:\S+ (?P<retcode>(315|401)) \S+ {channel} :.*",
+        {"match": r"(?i)^:\S+ (?P<retcode>(315|401)) \S+ {channel} :.*",
          "final": True},
     )
 
@@ -167,10 +168,10 @@ class WhoNick(AsyncEvents):
     send_line = 'WHO {nick}'
 
     events = (
-        {"match": "(?i)^:\S+ 352 \S+ (?P<channel>\S+) (?P<user>\S+) "
-                  "(?P<host>\S+) (?P<server>\S+) (?P<nick>{nick}) "
-                  "(?P<modes>\S+) :(?P<hopcount>\S+)\s*(?P<realname>.*)"},
-        {"match": "(?i)^:\S+ (?P<retcode>(315|401)) \S+ {nick} :.*",
+        {"match": r"(?i)^:\S+ 352 \S+ (?P<channel>\S+) (?P<user>\S+) "
+                  r"(?P<host>\S+) (?P<server>\S+) (?P<nick>{nick}) "
+                  r"(?P<modes>\S+) :(?P<hopcount>\S+)\s*(?P<realname>.*)"},
+        {"match": r"(?i)^:\S+ (?P<retcode>(315|401)) \S+ {nick} :.*",
          "final": True},
     )
 
@@ -187,7 +188,7 @@ class WhoNick(AsyncEvents):
 class IsOn(AsyncEvents):
 
     events = (
-        {"match": "(?i)^:\S+ 303 \S+ :(?P<nicknames>({nicknames_re}.*|$))",
+        {"match": r"(?i)^:\S+ 303 \S+ :(?P<nicknames>({nicknames_re}.*|$))",
          "final": True},
     )
 
@@ -204,8 +205,8 @@ class Topic(AsyncEvents):
     send_line = 'TOPIC {channel}{topic}'
 
     events = (
-        {"match": ("(?i)^:\S+ (?P<retcode>(331|332|TOPIC))"
-                   "(:?\s+\S+\s+|\s+){channel} :(?P<topic>.*)"),
+        {"match": (r"(?i)^:\S+ (?P<retcode>(331|332|TOPIC))"
+                   r"(:?\s+\S+\s+|\s+){channel} :(?P<topic>.*)"),
          "final": True},
     )
 
@@ -224,9 +225,9 @@ class Names(AsyncEvents):
     send_line = 'NAMES {channel}'
 
     events = (
-        {"match": "(?i)^:\S+ 353 .*{channel} :(?P<nicknames>.*)",
+        {"match": r"(?i)^:\S+ 353 .*{channel} :(?P<nicknames>.*)",
          'multi': True},
-        {'match': "(?i)^:\S+ (?P<retcode>(366|401)) \S+ {channel} :.*",
+        {'match': r"(?i)^:\S+ (?P<retcode>(366|401)) \S+ {channel} :.*",
          'final': True},
     )
 
@@ -244,10 +245,10 @@ class ChannelBans(AsyncEvents):
     send_line = 'MODE {channel} +b'
 
     events = (
-        {"match": "(?i)^:\S+ 367 \S+ {channel} (?P<mask>\S+) (?P<user>\S+) "
-                  "(?P<timestamp>\d+)",
+        {"match": r"(?i)^:\S+ 367 \S+ {channel} (?P<mask>\S+) (?P<user>\S+) "
+                  r"(?P<timestamp>\d+)",
          "multi": True},
-        {"match": "(?i)^:\S+ 368 \S+ {channel} :.*",
+        {"match": r"(?i)^:\S+ 368 \S+ {channel} :.*",
          "final": True},
     )
 
@@ -268,10 +269,10 @@ class CTCP(AsyncEvents):
     send_line = 'PRIVMSG {nick} :\x01{ctcp}\x01'
 
     events = (
-        {"match": "(?i):(?P<mask>\S+) NOTICE \S+ :\x01(?P<ctcp>\S+) "
+        {"match": "(?i):(?P<mask>\\S+) NOTICE \\S+ :\x01(?P<ctcp>\\S+) "
                   "(?P<reply>.*)\x01",
          "final": True},
-        {"match": "(?i)^:\S+ (?P<retcode>486) \S+ :(?P<reply>.*)",
+        {"match": r"(?i)^:\S+ (?P<retcode>486) \S+ :(?P<reply>.*)",
          "final": True}
     )
 
@@ -319,7 +320,7 @@ class Async:
             WhoChannelFlags.__name__,
             (WhoChannelFlags,),
             {"events": WhoChannelFlags.events + (
-                {"match": "(?i)^:\S+ 354 \S+ {0}".format(' '.join(regex)),
+                {"match": r"(?i)^:\S+ 354 \S+ {0}".format(' '.join(regex)),
                  "multi": True},
             )}
         )

--- a/irc3/plugins/autojoins.py
+++ b/irc3/plugins/autojoins.py
@@ -114,7 +114,7 @@ class AutoJoins:
         if target.nick == self.bot.nick:
             self.join(channel)
 
-    @irc3.event("^:\S+ 47[1234567] \S+ (?P<channel>\S+).*")
+    @irc3.event(r"^:\S+ 47[1234567] \S+ (?P<channel>\S+).*")
     def on_err_join(self, channel, **kwargs):
         """bot must try to rejoin later when he can't join"""
         if channel in self.handles:

--- a/irc3/plugins/fifo.py
+++ b/irc3/plugins/fifo.py
@@ -2,7 +2,7 @@
 import os
 import irc3
 from stat import S_ISFIFO
-__doc__ = '''
+__doc__ = r'''
 ==========================================
 :mod:`irc3.plugins.fifo` Fifo plugin
 ==========================================

--- a/irc3/plugins/quakenet.py
+++ b/irc3/plugins/quakenet.py
@@ -36,8 +36,8 @@ Usage::
 '''
 
 Q_NICK = "Q@CServe.quakenet.org"
-CHALLENGE_PATTERN = ("^:Q![a-zA-Z]+@CServe.quakenet.org NOTICE "
-                     "(?P<nick>\S+) :CHALLENGE (?P<challenge>[a-z0-9]+) ")
+CHALLENGE_PATTERN = (r"^:Q![a-zA-Z]+@CServe.quakenet.org NOTICE "
+                     r"(?P<nick>\S+) :CHALLENGE (?P<challenge>[a-z0-9]+) ")
 
 
 def get_digest(digest):

--- a/irc3/rfc.py
+++ b/irc3/rfc.py
@@ -131,11 +131,11 @@ PRIVMSG.re_out = MY_PRIVMSG.re_out
 CTCP = raw.new(
     'CTCP',
     regexp=(
-        '^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) '
+        r'^(@(?P<tags>\S+) )?:(?P<mask>\S+!\S+@\S+) '
         '(?P<event>(PRIVMSG|NOTICE)) '
         '{nick} :\x01(?P<ctcp>.*)\x01$'),
     regexp_out=(
-        '^(?P<event>(PRIVMSG|NOTICE)) (?P<target>\S+) :\x01(?P<ctcp>.*)\x01$'
+        '^(?P<event>(PRIVMSG|NOTICE)) (?P<target>\\S+) :\x01(?P<ctcp>.*)\x01$'
     ),
 )
 
@@ -157,5 +157,5 @@ TOPIC = raw.new(
 
 ERR_NICK = raw.new(
     'ERR_NICK',
-    "^(@(?P<tags>\S+) )?:(?P<srv>\S+) (?P<retcode>(432|433|436)) (?P<me>\S+) "
-    "(?P<nick>\S+) :(?P<data>.*)")
+    r"^(@(?P<tags>\S+) )?:(?P<srv>\S+) (?P<retcode>(432|433|436)) (?P<me>\S+) "
+    r"(?P<nick>\S+) :(?P<data>.*)")

--- a/irc3/tags.py
+++ b/irc3/tags.py
@@ -31,7 +31,7 @@ _unescapes = (
 
 # valid tag-keys must contain of alphanumerics and hyphens only.
 # for vendor-tagnames: TLD with slash appended
-_valid_key = re.compile("^([\w.-]+/)?[\w-]+$")
+_valid_key = re.compile(r"^([\w.-]+/)?[\w-]+$")
 
 # valid escaped tag-values must not contain
 # NUL, CR, LF, semicolons or spaces
@@ -51,7 +51,7 @@ def _escape(string):
 
 
 def encode(tags):
-    '''Encodes a dictionary of tags to fit into an IRC-message.
+    r'''Encodes a dictionary of tags to fit into an IRC-message.
     See IRC Message Tags: http://ircv3.net/specs/core/message-tags-3.2.html
 
     >>> from collections import OrderedDict
@@ -63,13 +63,13 @@ def encode(tags):
     >>> encode(d_ordered)
     'aaa=bbb;ccc;example.com/ddd=eee'
 
-    >>> d = {'key': 'value;with special\\\\characters', 'key2': 'with=equals'}
+    >>> d = {'key': 'value;with special\\characters', 'key2': 'with=equals'}
     >>> d_ordered = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
     >>> print(encode(d_ordered))
-    key=value\\:with\\sspecial\\\characters;key2=with=equals
+    key=value\:with\sspecial\\characters;key2=with=equals
 
-    >>> print(encode({'key': r'\\something'}))
-    key=\\\\something
+    >>> print(encode({'key': r'\something'}))
+    key=\\something
 
     '''
     tagstrings = []

--- a/irc3/utils.py
+++ b/irc3/utils.py
@@ -16,9 +16,9 @@ def slugify(value):
         value = value.decode('utf8', 'ignore')
     value = normalize('NFKD', value)
     value = value.encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s\.-]', '', value).strip().lower()
-    value = re.sub('[-\s]+', '-', value)
-    value = re.sub('-*\.+-*', '.', value)
+    value = re.sub(r'[^\w\s\.-]', '', value).strip().lower()
+    value = re.sub(r'[-\s]+', '-', value)
+    value = re.sub(r'-*\.+-*', '.', value)
     return value
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,7 +67,7 @@ class TestUtils(TestCase):
     def test_slugify(self):
         assert slugify('a test file .rst') == 'a-test-file.rst'
         assert slugify('a test/../ file .rst') == 'a-test.file.rst'
-        assert slugify('C:\\\\a test\../ file .rst') == 'ca-test.file.rst'
+        assert slugify(r'C:\\a test\../ file .rst') == 'ca-test.file.rst'
 
 
 class TestConfig(TestCase):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -16,7 +16,9 @@ class Payload:
 
 
 @pytest.mark.asyncio
-async def test_web_handler(irc3_bot_factory, aiohttp_raw_server, aiohttp_client):
+async def test_web_handler(
+    irc3_bot_factory, aiohttp_raw_server, aiohttp_client
+):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
     plugin.server_ready()
@@ -27,8 +29,9 @@ async def test_web_handler(irc3_bot_factory, aiohttp_raw_server, aiohttp_client)
 
 
 @pytest.mark.asyncio
-async def test_web_handler_post(irc3_bot_factory,
-                                aiohttp_raw_server, aiohttp_client):
+async def test_web_handler_post(
+    irc3_bot_factory, aiohttp_raw_server, aiohttp_client
+):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
 
@@ -42,8 +45,9 @@ async def test_web_handler_post(irc3_bot_factory,
 
 
 @pytest.mark.asyncio
-async def test_web_handler_post_auth(irc3_bot_factory,
-                                     aiohttp_raw_server, aiohttp_client):
+async def test_web_handler_post_auth(
+    irc3_bot_factory, aiohttp_raw_server, aiohttp_client
+):
     bot = irc3_bot_factory(**{
         'includes': ['irc3.plugins.web'],
         'irc3.plugins.web': {'api_key': 'toomanysecrets'},
@@ -66,7 +70,9 @@ async def test_web_handler_post_auth(irc3_bot_factory,
 
 
 @pytest.mark.asyncio
-async def test_web_handler_404(irc3_bot_factory, aiohttp_raw_server, aiohttp_client):
+async def test_web_handler_404(
+    irc3_bot_factory, aiohttp_raw_server, aiohttp_client
+):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -16,7 +16,7 @@ class Payload:
 
 
 @pytest.mark.asyncio
-async def test_web_handler(irc3_bot_factory, raw_test_server, test_client):
+async def test_web_handler(irc3_bot_factory, aiohttp_raw_server, aiohttp_client):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
     plugin.server_ready()
@@ -28,7 +28,7 @@ async def test_web_handler(irc3_bot_factory, raw_test_server, test_client):
 
 @pytest.mark.asyncio
 async def test_web_handler_post(irc3_bot_factory,
-                                raw_test_server, test_client):
+                                aiohttp_raw_server, aiohttp_client):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
 
@@ -43,7 +43,7 @@ async def test_web_handler_post(irc3_bot_factory,
 
 @pytest.mark.asyncio
 async def test_web_handler_post_auth(irc3_bot_factory,
-                                     raw_test_server, test_client):
+                                     aiohttp_raw_server, aiohttp_client):
     bot = irc3_bot_factory(**{
         'includes': ['irc3.plugins.web'],
         'irc3.plugins.web': {'api_key': 'toomanysecrets'},
@@ -66,7 +66,7 @@ async def test_web_handler_post_auth(irc3_bot_factory,
 
 
 @pytest.mark.asyncio
-async def test_web_handler_404(irc3_bot_factory, raw_test_server, test_client):
+async def test_web_handler_404(irc3_bot_factory, aiohttp_raw_server, aiohttp_client):
     bot = irc3_bot_factory(includes=['irc3.plugins.web'])
     plugin = bot.get_plugin(web.Web)
 


### PR DESCRIPTION
Happen that I got:

    Wed, 15 Dec 2021 19:13:06 +0000

stored in my ~/.irc3/feeds/discuss.updated, the only way to get a new post is to have
one posted on a wednesday now :D

It would probably have been cleaner to keep the same format instead of having to use `isoformat` and parse it back, but feedparser's dateparser is prefixed by an underscore, so I prefer not to use it :p

While doing it I also spotted a small error in the datetime constructions: `datetime.datetime(*e.updated_parsed[:7])`, taking 7 elements takes the `tm_wday` (weekday) and use it as a microsecond, so I changed it to `[:6]`.

While I was there I fixed `tox -e flake8`, there were a few "unrecognized escape sequences" (a warning since Python 3.6 [that may become a SyntaxError in the future](https://docs.python.org/3/reference/lexical_analysis.html?highlight=backslash#string-and-bytes-literals)).

I however have hard times to have the test pass, I'm hitting a `fixture 'raw_test_server' not found` (both I my branch and master), and I have to sleep now.

