### PR TITLE
Spotted that requests session may not be thread-safe.

### DIFF
--- a/irc3/plugins/feeds.py
+++ b/irc3/plugins/feeds.py
@@ -69,6 +69,7 @@ HEADERS = {
     'Pragma': 'no-cache',
 }
 
+
 def default_hook(entries):
     """Default hook called for each entry"""
     return entries
@@ -146,7 +147,6 @@ class Feeds:
     """Feeds plugin"""
 
     PoolExecutor = ThreadPoolExecutor
-
 
     def __init__(self, bot):
         bot.feeds = self


### PR DESCRIPTION
Bonjour Gawel,

See: https://github.com/psf/requests/issues/2766

It may become thread-safe again in the future, but I don't think irc3 gets a good benefit of using `Session` objects, if I understand correctly it only allow connection pooling (and parameter sharing), but as irc3 only do HTTP requests every now and then, the connections are probably not recycled anyway (I bet they just timeout). If I'm true it's probably even nicer (for webservers) **not** using a `requests.Session`, so we close TCP connections right away instead of trying to keep them open for nothing.

(I don't like when I try to guess performances-related things, bad practice at its finest...)

`irc3` used `requests.Session` to configure the headers once for all, so I used a global constant instead.

There's other places in `irc3` where `requests.Session` is used, I havent looked at it, I wanted to discuss this PR first.

Beware it's not deeply tested, I'll use my branch to run [alain](https://github.com/afpy/alain/) for a few days, it'll be a good test.

Last thing, I discovered this while trying to implement an `ics` module, where `irc3` could subscribe to calendar and talk about [upcoming events](https://discuss.afpy.org/upcoming-events), does it looks like a good idea to you, would you enjoy a PR with it (it's not ready yet)?

Bonne journée !
