### PR TITLE
Use aiohttp instead of requests in feed plugin

### DIFF
--- a/irc3/compat.py
+++ b/irc3/compat.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-import types
 
 PY34 = bool(sys.version_info[0:2] >= (3, 4))
 PY35 = bool(sys.version_info[0:2] >= (3, 5))

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = ['venusian>=3.0', 'docopt']
 test_requires = [
     'pytest-asyncio',
     'pytest-aiohttp',
+    'aiohttp',
     'feedparser',
     'requests',
     'pysocks',


### PR DESCRIPTION
Spotted that `--debug` was not documented, so I added it, in the right place I hope.

Spotted a deprecated mention of `buildout`, replaced it with a mention of `pip install .`.

Flake8 spotted an unused `import types` in `compat`, I hope it's not a false positive, fixed it because I bet the CI won't pass if it's not fixed.

But the main task was replacing aiohttp with requests in the feed plugin.