### PR TITLE
Fix `TestCron`

### DIFF
--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from irc3.testing import BotTestCase
 from irc3.testing import MagicMock
 from irc3.plugins import cron
@@ -74,5 +75,8 @@ class TestCron(BotTestCase):
             asyncio.ensure_future(
                 c.next(), loop=loop).add_done_callback(complete)
 
-        loop.run_until_complete(f)
+        try:
+            loop.run_until_complete(asyncio.wait_for(f, timeout=61))
+        except asyncio.TimeoutError:
+            pytest.fail(f"Test timed out waiting for cron jobs. Results: {results}")
         assert results == [bot, bot]

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -11,12 +11,12 @@ class MyCron:
     def __init__(self, bot):
         self.bot = bot
 
-    @cron.cron('* * * * * *')
+    @cron.cron('* * * * *')
     def method(self):
         return self.bot
 
 
-@cron.cron('* * * * * *')
+@cron.cron('* * * * *')
 async def function(bot):
     return bot
 


### PR DESCRIPTION
The problem with `TestCron.test_callable` is that CronSim doesn't support seconds the way croniter does. The updated test passes, except you may have to wait up to a minute.
