### PR TITLE
Split long messages based on byte length

### DIFF
--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -227,9 +227,10 @@ class IrcBot(base.IrcObject):
         if message:
             is_dcc = isinstance(target, DCCChat)
             prefix = '' if is_dcc else 'PRIVMSG %s :' % target
-            messages = utils.split_message(
+            messages = utils.split_message_byte_len(
                 message,
                 self.config.max_length,
+                self.encoding,
                 prefix=prefix,
             )
             if is_dcc:
@@ -251,9 +252,10 @@ class IrcBot(base.IrcObject):
         if message:
             is_dcc = isinstance(target, DCCChat)
             prefix = '' if is_dcc else 'NOTICE %s :' % target
-            messages = utils.split_message(
+            messages = utils.split_message_byte_len(
                 message,
                 self.config.max_length,
+                self.encoding,
                 prefix=prefix,
             )
             if is_dcc:
@@ -269,7 +271,11 @@ class IrcBot(base.IrcObject):
     def ctcp(self, target, message, nowait=False):
         """send a ctcp to target"""
         if target and message:
-            messages = utils.split_message(message, self.config.max_length)
+            messages = utils.split_message_byte_len(
+                message,
+                self.config.max_length,
+                self.encoding,
+            )
             f = None
             for message in messages:
                 f = self.send_line('PRIVMSG %s :\x01%s\x01' % (target,
@@ -280,7 +286,11 @@ class IrcBot(base.IrcObject):
     def ctcp_reply(self, target, message, nowait=False):
         """send a ctcp reply to target"""
         if target and message:
-            messages = utils.split_message(message, self.config.max_length)
+            messages = utils.split_message_byte_len(
+                message,
+                self.config.max_length,
+                self.encoding,
+            )
             f = None
             for message in messages:
                 f = self.send_line('NOTICE %s :\x01%s\x01' % (target, message),

--- a/irc3/__init__.py
+++ b/irc3/__init__.py
@@ -227,7 +227,7 @@ class IrcBot(base.IrcObject):
         if message:
             is_dcc = isinstance(target, DCCChat)
             prefix = '' if is_dcc else 'PRIVMSG %s :' % target
-            messages = utils.split_message_byte_len(
+            messages = utils.split_message(
                 message,
                 self.config.max_length,
                 self.encoding,
@@ -252,7 +252,7 @@ class IrcBot(base.IrcObject):
         if message:
             is_dcc = isinstance(target, DCCChat)
             prefix = '' if is_dcc else 'NOTICE %s :' % target
-            messages = utils.split_message_byte_len(
+            messages = utils.split_message(
                 message,
                 self.config.max_length,
                 self.encoding,
@@ -271,7 +271,7 @@ class IrcBot(base.IrcObject):
     def ctcp(self, target, message, nowait=False):
         """send a ctcp to target"""
         if target and message:
-            messages = utils.split_message_byte_len(
+            messages = utils.split_message(
                 message,
                 self.config.max_length,
                 self.encoding,
@@ -286,7 +286,7 @@ class IrcBot(base.IrcObject):
     def ctcp_reply(self, target, message, nowait=False):
         """send a ctcp reply to target"""
         if target and message:
-            messages = utils.split_message_byte_len(
+            messages = utils.split_message(
                 message,
                 self.config.max_length,
                 self.encoding,

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -423,7 +423,7 @@ class Commands(dict):
                         buf += line + ' '
                     else:
                         if buf is not None:
-                            for b in utils.split_message_byte_len(
+                            for b in utils.split_message(
                                 buf,
                                 160,
                                 self.context.encoding,
@@ -443,7 +443,7 @@ class Commands(dict):
             cmds = sorted((k for (k, (p, m)) in self.items()
                            if p.get('show_in_help_list', True)))
             cmds_str = ', '.join([self.cmd + k for k in cmds])
-            lines = utils.split_message_byte_len(
+            lines = utils.split_message(
                 'Available commands: %s ' % cmds_str,
                 160,
                 self.context.encoding,

--- a/irc3/plugins/command.py
+++ b/irc3/plugins/command.py
@@ -423,7 +423,11 @@ class Commands(dict):
                         buf += line + ' '
                     else:
                         if buf is not None:
-                            for b in utils.split_message(buf, 160):
+                            for b in utils.split_message_byte_len(
+                                buf,
+                                160,
+                                self.context.encoding,
+                            ):
                                 yield b
                             buf = None
                         line = line.replace('%%', self.context.config.cmd)
@@ -439,8 +443,11 @@ class Commands(dict):
             cmds = sorted((k for (k, (p, m)) in self.items()
                            if p.get('show_in_help_list', True)))
             cmds_str = ', '.join([self.cmd + k for k in cmds])
-            lines = utils.split_message(
-                'Available commands: %s ' % cmds_str, 160)
+            lines = utils.split_message_byte_len(
+                'Available commands: %s ' % cmds_str,
+                160,
+                self.context.encoding,
+            )
             for line in lines:
                 yield line
             url = self.config.get('url')

--- a/irc3/utils.py
+++ b/irc3/utils.py
@@ -5,7 +5,6 @@ from . import tags
 import configparser
 import importlib
 import functools
-import textwrap
 import logging
 import os
 import re
@@ -157,20 +156,9 @@ class IrcString(str):
 
 
 SPACE = ' '
-STRIPPED_CHARS = '\t '
 
 
-def split_message(message, max_length, prefix=''):
-    """Split long messages"""
-    max_length = max_length - len(prefix)
-    if len(message) > max_length:
-        for message in textwrap.wrap(message, max_length):
-            yield message
-    else:
-        yield message.rstrip(STRIPPED_CHARS)
-
-
-def split_message_byte_len(message, max_bytes, encoding, prefix=''):
+def split_message(message, max_bytes, encoding, prefix=''):
     """Split long messages based on byte length, ensuring chunks
     do not exceed max_bytes when encoded. Break up words when necessary.
     """

--- a/irc3d/__init__.py
+++ b/irc3d/__init__.py
@@ -168,7 +168,7 @@ class IrcServer(base.IrcObject):
     def notice(self, client, message):
         """send a notice to client"""
         if client and message:
-            messages = utils.split_message_byte_len(
+            messages = utils.split_message(
                 message,
                 self.config.max_length,
                 self.encoding,

--- a/irc3d/__init__.py
+++ b/irc3d/__init__.py
@@ -168,7 +168,11 @@ class IrcServer(base.IrcObject):
     def notice(self, client, message):
         """send a notice to client"""
         if client and message:
-            messages = utils.split_message(message, self.config.max_length)
+            messages = utils.split_message_byte_len(
+                message,
+                self.config.max_length,
+                self.encoding,
+            )
             for msg in messages:
                 client.fwrite(':{c.srv} NOTICE {c.nick} :{msg}', msg=msg)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 from irc3.utils import IrcString
 from irc3.utils import maybedotted
-from irc3.utils import split_message, split_message_byte_len
+from irc3.utils import split_message
 from irc3.utils import parse_config_env
 from irc3.utils import slugify
 from irc3.testing import ini2config
@@ -103,18 +103,7 @@ class TestConfig(TestCase):
 
 class TestSplit(TestCase):
 
-    def callFTU(self, messages, max_length=10):
-        return list(split_message(' '.join(messages), max_length))
-
     def test_split_message(self):
-        messages = ['allo', 'alloallo']
-        self.assertEqual(messages, self.callFTU(messages))
-        messages = ['allo\t', 'alloallo']
-        self.assertEqual([m.strip() for m in messages], self.callFTU(messages))
-        messages = ['\x1d \x1f']
-        self.assertEqual(messages, self.callFTU(messages))
-
-    def test_split_message_byte_len(self):
         messages = [
             'allo',
             'allo\t',
@@ -140,12 +129,12 @@ class TestSplit(TestCase):
         ]
 
         split = [
-            list(split_message_byte_len(msg, 10, 'utf-8'))
+            list(split_message(msg, 10, 'utf-8'))
             for msg in messages
         ]
         self.assertEqual(split, expected)
 
-    def test_split_message_byte_len_long(self):
+    def test_split_message_long(self):
         message = (
             'Harum qui commodi voluptas veritatis provident voluptatem '
             'accusamus. Ut odio porro voluptas. Totam perspiciatis dolorem '
@@ -204,17 +193,17 @@ class TestSplit(TestCase):
 
         for max_bytes in expected.keys():
             split = list(
-                split_message_byte_len(message, max_bytes, 'utf-8')
+                split_message(message, max_bytes, 'utf-8')
             )
             self.assertEqual(split, expected[max_bytes])
 
-    def test_split_message_byte_len_no_whitespace(self):
+    def test_split_message_no_whitespace(self):
         message_len = 100
         message = 'A' * message_len
 
         def split_lens(max_bytes):
             split = list(
-                split_message_byte_len(message, max_bytes, 'utf-8')
+                split_message(message, max_bytes, 'utf-8')
             )
             return len(''.join(split)), len(split)
 
@@ -250,4 +239,4 @@ class TestSplit(TestCase):
 
         for max_bytes in (1, 2):
             with self.assertRaisesRegex(ValueError, f'{max_bytes=}'):
-                list(split_message_byte_len(message, max_bytes, 'utf-8'))
+                list(split_message(message, max_bytes, 'utf-8'))


### PR DESCRIPTION
This PR implements a new `utils` function `split_message_byte_len(message, max_bytes, encoding, prefix='')`. The function splits a string into a list of string chunks, each chunk up to `max_bytes` bytes. It ensures IRC messages stay under their byte limit.

The fact the function ~~returns `list[str]`~~ yields `str` makes it easy to replace existing uses of `split_message`. I tried returning `bytes`, and it required more thorough modification of the `split_message` call sites. For example, you had to replace string literals with byte literals and add checks like the following to `write` functions:

```none
if not isinstance(data, bytes):
    data = data.encode(self.encoding)
```

It seems best to avoid this; Python programmers normally work with strings.

We only split on spaces and preserve other whitespace for reasons outlined in 3e58d55fa879c4e0aa5fa83d3bf838b047ad6cf1.

Existing `split_message` is kept unchanged for plugin code that may use it.

Resolves #191.
