### PR TITLE
Close temporarily created event loop

### DIFF
--- a/irc3/testing.py
+++ b/irc3/testing.py
@@ -56,8 +56,9 @@ class IrcBot(irc3.IrcBot):
     def __init__(self, **config):
         self.check_required()
         if 'loop' not in config:
-            loop = asyncio.new_event_loop()
-            loop = mock.create_autospec(loop, spec_set=True)
+            tmp_loop = asyncio.new_event_loop()
+            loop = mock.create_autospec(tmp_loop, spec_set=True)
+            tmp_loop.close()
             loop.call_later = call_later
             loop.call_soon = call_soon
             loop.time.return_value = 10


### PR DESCRIPTION
`IrcBot` creates an event loop for `mock.create_autospec`, but it is then dropped on the floor. Close it before dropping it.